### PR TITLE
Add beta requirement for preserving container-disk image during live …

### DIFF
--- a/veps/sig-compute/image-volume-proposal.md
+++ b/veps/sig-compute/image-volume-proposal.md
@@ -161,6 +161,7 @@ include scenarios involving custom kernel boot / initrd and containerdisk.
 ### Beta
 - Wait for the imageVolume feature gate to be graduated to GA in Kubernetes.
 - Enable feature gate by default
+- Ensure that live migration completes successfully by preserving the original container-disk image if the tag is overwritten.
 
 ### GA
 - Remove all code for the old method in virt-handler, virt-controller, and virt-launcher, but continue supporting the 


### PR DESCRIPTION
If the image changes to a different disk file, migration will likely fail as well. To handle this, we would need the imageVolume to report the image's digest, similar to how the imageID field works in containerStatus. One possible solution is to create a sidecar container with the same image that does nothing, in order to retrieve the digest during migration. However, I believe it is better to wait until imageVolume reaches GA in Kubernetes, as they may add digest reporting by then.

[A related comment](https://github.com/kubernetes/enhancements/issues/4639#issuecomment-2733658072)

FYI @vladikr @iholder101 @xpivarc

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
