### PR TITLE
chore(PULL_REQUEST_TEMPLATE.md): Use newline for `/sig` example command comment

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,9 +1,15 @@
 ### VEP Metadata
 
-**Tracking issue**: <!-- For example, https://github.com/kubevirt/enhancements/pull/2 -->
-**SIG label**: <!-- For example, /sig $SIG -->
+**Tracking issue**:
+
+<!-- For example, https://github.com/kubevirt/enhancements/pull/2 -->
+
+**SIG label**:
+
+<!-- For example, /sig $SIG -->
 
 ### What this PR does
+
 <!-- Please summarize the VEP update here -->
 
 ### Special notes for your reviewer


### PR DESCRIPTION
The `/sig` command needs to be on a new line to work so lets try to get folks to do this during submission by moving the example comment on to a new line. Other comments are also placed on a new lines to help re-enforce this.
