### PR TITLE
Fix typo in VEP template

### DIFF
--- a/veps/NNNN-vep-template/vep.md
+++ b/veps/NNNN-vep-template/vep.md
@@ -30,7 +30,7 @@ The desired outcome
 
 <!--
 Why this enhancement is important Limitations to the scope of the design
-<!--
+-->
 
 ## Definition of Users
 


### PR DESCRIPTION
One of the inline comments was incorrectly formatted.

### VEP Metadata

**Tracking issue**: <!-- For example, https://github.com/kubevirt/enhancements/pull/2 -->
**SIG label**: <!-- For example, /sig $SIG -->

### What this PR does

This fixes a minor typo in the template. It doesn't affect the rendered markdown view, but it's a bit annoying in the editor view. 

### Special notes for your reviewer
