### PR TITLE
Update Beta and GA requirements for ImageVolume

### DIFF
--- a/veps/sig-compute/16-image volume/image-volume-proposal.md
+++ b/veps/sig-compute/16-image volume/image-volume-proposal.md
@@ -171,13 +171,11 @@ include scenarios involving custom kernel boot / initrd and containerdisk.
 
 ### Beta
 - Wait for the imageVolume feature gate to be graduated to GA in Kubernetes.
-- Enable feature gate by default
 - Ensure that live migration completes successfully by preserving the original container-disk image if the tag is overwritten.
 
 ### GA
-- Remove all code for the old method in virt-handler, virt-controller, and virt-launcher, but continue supporting the 
-old virt-launchers in virt-handler.
-- For VMs not supporting migration we should have alerts and long enough grace period
 
 ### Post-GA
-Remove any remaining code for the old method in virt-handler once it is safe from upgrade perspective.
+- Remove all code for the old method in virt-handler, virt-controller, and virt-launcher, but continue supporting the
+  old virt-launchers in virt-handler.
+- Remove any remaining code for the old method in virt-handler once it is safe from upgrade perspective.


### PR DESCRIPTION
### VEP Metadata

**Tracking issue**: https://github.com/kubevirt/enhancements/issues/16
**SIG label**: sig/compute

### What this PR does
- Removes "Enable feature gate by default" from Beta requirements (this is implicit now for every FG)
- Moves code cleanup tasks (removing old container-disk bind mount method) from GA to Post-GA, since virt-handler still needs to handle upgrades for existing VMIs.
- Removes the alert/grace period requirement for non-migratable VMs from GA.

### Special notes for your reviewer
