### PR TITLE
Self nominate as an approver

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,6 +2,7 @@
 approvers:
   - vladikr
   - xpivarc
+  - iholder101
 reviewers:
   - lyarwood
 


### PR DESCRIPTION
### What this PR does
In this PR, I nominate myself to become an approver of this repo.

I believe to be one of the forces to initiate the VEP process in Kubevirt. Since then, I regularly lead the sig-compute call and invest effort in planning, reviewing and promoting the VEP process in general.

I think this PR reflects the effort I already put into the VEP process, and hope my participation as an approver in this repo could benefit the organization, especially since there are so few approvers.