### PR TITLE
VEP-10 (extension): Add SR-IOV Network DRA support

### DIFF
--- a/veps/sig-compute/10-dra-devices/vep.md
+++ b/veps/sig-compute/10-dra-devices/vep.md
@@ -25,6 +25,9 @@ control of their devices using Virtual Machines and Containers.
 ## Non Goals
 
 - Replace device-plugin support in KubeVirt
+- Replace existing SR-IOV network integration (Multus-based approach remains fully supported)
+- Deploy DRA SR-IOV driver (will be done as part of sriov-network-operator)
+- Support co existance of both DRA SR-IOV driver and Device plugin
 - Align on what drivers KubeVirt will support in tree
 - Address any complexity issues when DRA APIs in KubeVirt
 
@@ -50,7 +53,8 @@ control of their devices using Virtual Machines and Containers.
 1. Devices where the DRA driver sets agreed upon attributes for resources in ResourceSlice.
     1. PCIe Bus address for pGPU.
     2. Mediated device uuid for vGPU.
-1. Devices have to either be of the type GPU or HostDevices.
+    3. PCIe Bus address for SR-IOV network devices.
+2. Devices have to be of the type GPU, HostDevices, or Network devices (SR-IOV or Scalable Funtions in the future).
 
 ### Future Usecases
 1. NVMe devices https://github.com/kubevirt/community/issues/254
@@ -62,14 +66,10 @@ control of their devices using Virtual Machines and Containers.
    be supported.
     1. In the future a standardization could be envisioned for a PCI device where the attributes are set
        automatically through the DRA framework. When this is achieved, any DRA device should be available in KubeVirt VMs
-2. NetworkDevices or Storage Devices which need a lifecycle of its own will not be supported through HostDevices in alpha
-   release.
+2. Storage Devices which need a lifecycle of their own will not be supported through HostDevices in alpha release.
    - For storage, NVMe devices may need to persist beyond pod deletion (e.g., during VM pause). However, current K8s 
      DRA implementation deletes resource claims when the virt-launcher pod is deleted. Managing claims beyond pod 
-     lifecycle (for example VM pause case) is out of scope for this design. 
-   - For network devices, there is already existing mechanism of configuring the network, any DRA network device will have
-     to work existing functionality. There is a need to explore ideas on how to best achieve it potential in sig-network.
-     Hence, it is out of scope, will have to be picked up as a separate VEP
+     lifecycle (for example VM pause case) is out of scope for this design.
 
 ## Repos
 
@@ -82,13 +82,14 @@ For allowing users to consume DRA devices, there are two main changes needed:
 1. API changes and the plumbing required in KubeVirt to generate the domain xml with the devices.
 2. Driver Implementation to set the required attributes for KubeVirt to use
 
-This design document focuses on part 1 of the problem. This design is introducing two new feature gates:
+This design document focuses on part 1 of the problem. This design is introducing three new feature gates:
 1. GPUsWithDRA
 2. HostDevicesWithDRA
-All the API changes will be gated behind either one of these feature gates so as not to break existing functionality.
+3. DRANetworkDevices
 
-Both the GPUs as well as HostDevices have separate lifecycle but essentially have the same API, hence two separate
-feature gates are required.
+All the API changes will be gated behind one of these feature gates so as not to break existing functionality.
+
+GPUs, HostDevices, and NetworkDevices have separate lifecycles but share similar DRA integration patterns. The three separate feature gates allow independent control of each device type.
 
 ### API Changes
 
@@ -239,6 +240,83 @@ The virt-launcher will have the logic of converting a GPU device into its corres
 will continue to look for env variables (current approach). For DRA devices, it will use the vmi status section to
 generate the domain xml.
 
+### Network DRA Integration
+
+Unlike GPUs and HostDevices which are specified in `spec.domain.devices`, network devices already have a natural place in the KubeVirt API at `spec.networks`.
+To support DRA-provisioned network devices (such as SR-IOV NICs), a new network source type `ResourceClaimNetworkSource` has been added to the existing `NetworkSource` type.
+
+```go
+// Represents the source resource that will be connected to the vm.
+// Only one of its members may be specified.
+type NetworkSource struct {
+	Pod           *PodNetwork                 `json:"pod,omitempty"`
+	Multus        *MultusNetwork              `json:"multus,omitempty"`
+	ResourceClaim *ResourceClaimNetworkSource `json:"resourceClaim,omitempty"`
+}
+
+// ResourceClaimNetworkSource represents a network resource requested
+// via a Kubernetes ResourceClaim.
+type ResourceClaimNetworkSource struct {
+	// ClaimName references the name of a ResourceClaim in the
+	// VMI's namespace that provides the network resource.
+	// +kubebuilder:validation:MinLength=1
+	ClaimName string `json:"claimName"`
+
+	// RequestName specifies which request from the
+	// ResourceClaim.spec.devices.requests array this network
+	// source corresponds to.
+	// +kubebuilder:validation:MinLength=1
+	RequestName string `json:"requestName"`
+}
+```
+
+#### Network DRA Status Reporting
+
+For consistency with GPUs and HostDevices, DRA-provisioned network devices populate the same
+`vmi.status.deviceStatus.hostDeviceStatuses[]` array. The DRA controller in virt-controller:
+
+1. Identifies networks with `resourceClaim` source type
+2. Extracts device information from the allocated ResourceClaim and ResourceSlice
+3. Populates `hostDeviceStatuses` with network name and allocated device attributes (PCI address)
+
+The status entry name matches the network name from `spec.networks[].name`, allowing virt-launcher to correlate
+the network configuration with its allocated DRA device.
+
+#### SR-IOV Integration
+
+The initial implementation supports SR-IOV network devices via DRA. When a network interface has `sriov` binding
+and references a network with `resourceClaim` source:
+
+1. The network admitter validates that exactly one network source type (pod, multus, or resourceClaim) is specified
+2. Virt-controller adds the resource claim to the virt-launcher pod spec via `WithNetworksDRA()` render option
+3. The DRA controller populates device status with the PCI address from the ResourceSlice
+4. Virt-launcher's SR-IOV implementation (`CreateDRAHostDevices()`) reads the PCI address from device status and
+   generates the appropriate libvirt hostdev XML, just as it does for traditional Multus-based SR-IOV
+
+This approach allows network DRA devices to leverage existing KubeVirt networking infrastructure while using
+DRA for device allocation, providing a clean separation between device provisioning (DRA) and network configuration
+(KubeVirt networks API).
+
+**Important:** The traditional Multus-based SR-IOV API (using `multus` network source) and the DRA-based SR-IOV API
+(using `resourceClaim` network source) are **mutually exclusive per VM**. A single VMI should not mix both approaches.
+The existing Multus-based SR-IOV API remains fully supported and unchanged.
+
+##### Custom MAC Address Support
+
+To support custom MAC addresses for DRA-based SR-IOV networks, KubeVirt will annotate the virt-launcher pod with the 
+requested MAC addresses. The MAC address is taken from the existing `spec.domain.devices.interfaces[].macAddress` field:
+```
+kubevirt.io/dra-networks: '[{"claimName":"sriov","requestName":"vf","mac":"de:ad:00:00:be:ef"}]'
+```
+It will preserve the structure of `k8s.v1.cni.cncf.io/networks`, but for claimName,requestName instead of NAD.
+
+The SR-IOV DRA driver reads this annotation and passes the claim/request identifier along with the MAC address to the SR-IOV CNI, ensuring the network interface is configured with the specified MAC address.
+
+Note: it is planned that Kubevirt will support "auto" mode, where the ResourceClaim is created by Kubevirt,
+and a ResourceClaim includes a config that supports MAC address field.
+Since Kubevirt also support cases where the ResourceClaim / ResourceClaimTemplate are created by the admin,
+we need to give a solution for the general case, therefore the annotation serves both of the cases.
+
 ### DRA API for reading device related information
 
 The examples below shows the APIs used to generate the vmi.status.deviceStatus section:
@@ -351,6 +429,9 @@ spec:
 ### Webhook changes
 
 1. Allow the VMI only if vmi spec is correct, i.e. resource claims for requested devices are specified
+2. Validate that a network with a `resourceClaim` source has a corresponding interface with `sriov` binding.
+3. Validate that no two entities (two networks, two hostDevices, or a network and a hostDevice) reference the same `claimName` + `requestName` combination. If multiple devices need to share resources from the same claim, two separate entries under `vmi.spec.resourceClaims` must be created, and each device should reference a distinct entry.
+4. Validate that a VMI does not mix Multus-based SR-IOV (using `multus` network source) and DRA-based SR-IOV (using `resourceClaim` network source). The two approaches are mutually exclusive per VM.
 
 Note: The feature gate verification when VMI requesting DRA device will either be done in webhook or controller, TBD
 
@@ -359,24 +440,38 @@ Note: The feature gate verification when VMI requesting DRA device will either b
 
 1. If devices are requested using DRA, virt controller needs to render the virt-launcher manifest such that
    `pod.spec.resourceClaims` and `pod.spec.containers.resources.claim` sections are filled out.
-1. virt-controller needs a mechanism to watch for virt-launcher pods, resourceclaims and resourceslices to populate the
+   - For GPUs and HostDevices: claims from `vmi.spec.resourceClaims[]` referenced by devices
+   - For Network devices: claims from `vmi.spec.resourceClaims[]` referenced by `vmi.spec.networks[].resourceClaim` 
+2. virt-controller needs a mechanism to watch for virt-launcher pods, resourceclaims and resourceslices to populate the
    `vmi.status.deviceStatus` using the steps mentioned in above section that has all the attributes (for example the
    pciAddress for the gpu device):
     1. The pod status has information about the allocated/reserved resourceClaim.
-    1. The resourceClaim has information about the individual requests in the claim and their allocated device names.
-    1. The resourceslice corresponding to the node running the VMI has information about the allocated device.
+    2. The resourceClaim has information about the individual requests in the claim and their allocated device names.
+    3. The resourceslice corresponding to the node running the VMI has information about the allocated device.
 
 ### Virt launcher changes
 
 1. For devices generated using DRA, virt-launcher needs to use the vmi.status.deviceStatus to generate the domain xml
    instead of environment variables as in the case of device-plugins
-1. The standard env variables `PCI_RESOURCE_<deviceName>` and `MDEV_PCI_RESOURCE_<deviceName>` may continue to be set
+2. The standard env variables `PCI_RESOURCE_<deviceName>` and `MDEV_PCI_RESOURCE_<deviceName>` may continue to be set
    as fallback mechanisms but the focus here is to ensure we can consume the device PCIe bus address attribute from the
    allocated devices in virt-launcher to generate the domain xml.
-1. Both GPU and HostDevice devices requested in the domain spec will have corresponding entries in the VMI status
-   at `status.deviceStatus.gpuStatuses[*]`/`status.deviceStatus.hostDeviceStatuses[*]`. From here, the relevant
-   device attributes can be inferred by virt-launcher (`pciAddress` attr) to generate the domain xml with the appropriate
-   gpu/hostdev spec.
+3. GPU, HostDevice, and Network (SR-IOV) devices will have corresponding entries in the VMI status:
+   - GPUs: `status.deviceStatus.gpuStatuses[*]`
+   - HostDevices: `status.deviceStatus.hostDeviceStatuses[*]`
+   - Network devices: `status.deviceStatus.hostDeviceStatuses[*]` (using network name as key)
+   From here, the relevant device attributes can be inferred by virt-launcher (`pciAddress` attr) to generate the 
+   domain xml with the appropriate gpu/hostdev spec.
+4. For SR-IOV networks with DRA, the `CreateDRAHostDevices()` function generates hostdev XML by:
+   - Filtering interfaces with SRIOV binding that reference networks with resourceClaim source
+   - Looking up the corresponding device status entry by network name
+   - Extracting the PCI address from device status attributes
+   - Generating standard libvirt hostdev XML, identical to traditional Multus-based SR-IOV
+
+Note:
+In case Kubevirt requests n interfaces and the file has N > n interfaces, Kubevirt will use the first n,
+and optionally print a warning about it (can happen for example if count != on the ResourceClaim/ResourceClaimTempalte).
+If N < n, virt-launcher will return an error, as this isn't recoverable.
 
 ## API Examples
 
@@ -452,6 +547,87 @@ status:
   resourceClaimStatuses:
   - name: gpu-resource-claim
     resourceClaimName: virt-launcher-vmi-fedora-9bjwb-gpu-resource-claim-m4k28
+```
+
+### VMI API with DRA SR-IOV Network
+
+```yaml
+---
+# Cluster-scoped DeviceClass for network devices
+apiVersion: resource.k8s.io/v1
+kind: DeviceClass
+metadata:
+  name: sriov.network.example.com
+spec:
+  selectors:
+  - cel:
+      expression: device.driver == 'sriov.network.example.com'
+---
+# ResourceClaimTemplate for SR-IOV network device
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaimTemplate
+metadata:
+  name: sriov-network-claim-template
+  namespace: default
+spec:
+  spec:
+    devices:
+      requests:
+      - name: sriov-nic-request
+        exactly:
+          deviceClassName: sriov.network.example.com
+---
+# VMI using DRA for SR-IOV network
+apiVersion: kubevirt.io/v1
+kind: VirtualMachineInstance
+metadata:
+  name: vmi-sriov-dra
+  namespace: default
+spec:
+  domain:
+    devices:
+      interfaces:
+      - name: sriov-net
+        sriov: {}
+  networks:
+  - name: sriov-net
+    resourceClaim:
+      claimName: sriov-network-claim
+      requestName: sriov-nic-request
+  resourceClaims:
+  - name: sriov-network-claim
+    resourceClaimTemplateName: sriov-network-claim-template
+status:
+  deviceStatus:
+    hostDeviceStatuses:
+    - name: sriov-net
+      deviceResourceClaimStatus:
+        name: 0000-05-00-1
+        resourceClaimName: virt-launcher-vmi-sriov-dra-sriov-network-claim-abc123
+        attributes:
+          pciAddress: 0000:05:00.1
+---
+# Generated virt-launcher pod
+apiVersion: v1
+kind: Pod
+metadata:
+  name: virt-launcher-vmi-sriov-dra
+  namespace: default
+spec:
+  containers:
+  - name: compute
+    image: virt-launcher
+    resources:
+      claims:
+      - name: sriov-network-claim
+        request: sriov-nic-request
+  resourceClaims:
+  - name: sriov-network-claim
+    resourceClaimTemplateName: sriov-network-claim-template
+status:
+  resourceClaimStatuses:
+  - name: sriov-network-claim
+    resourceClaimName: virt-launcher-vmi-sriov-dra-sriov-network-claim-abc123
 ```
 
 ## Comparing DRA APIs with Device Plugins
@@ -649,11 +825,32 @@ to look up the env variable: `PCI_RESOURCE_<RESOURCE-CLAIM-NAME>_<REQUEST-NAME>`
 
 ## Handling Future usecase of Live Migration
 
-For the purposes of this document, live migrating a VMI with GPU design is currently out-of-scope as it is not currently
-supported in KubeVirt. However, in the future this usecase could be supported. The following are two ways in which it
-could be handled
+For the purposes of this document, live migrating a VMI with DRA devices is currently out-of-scope. However, in the 
+future this usecase could be supported.
 
-### Alternative 1
+### Network DRA Migration (Planned Approach)
+
+Live migration for network DRA devices will be supported in a follow-up implementation. The planned approach addresses
+the limitation that `vmi.status.deviceStatus` is not the appropriate place for pod-specific context during migration
+(when both source and target pods exist).
+
+Instead, combination of CDI (Container Device Interface) and NRI, will inject device information as a file into each pod. 
+Amoung other information, the file structure will contain mappings of request/claim to PCI addresses.
+Please see https://github.com/k8snetworkplumbingwg/dra-driver-sriov/pull/62
+
+During migration, virt-launcher on both source and target pods will read their respective device information files, 
+similar to how the downward API is used today for pod metadata. This ensures each virt-launcher has the correct device 
+context for its pod without conflicts in the VMI status.
+
+Initially, the SR-IOV DRA driver will be responsible for injecting this file. In the future, there is a plan for 
+Kubernetes itself to provide this functionality (see [kubernetes/enhancements#5606](https://github.com/kubernetes/enhancements/pull/5606)), 
+at which point the entire `vmi.status.deviceStatus` mechanism could be replaced by this file-based approach across all DRA device types (GPUs, HostDevices, and Networks).
+
+### GPU and HostDevice Migration Alternatives
+
+The following are potential ways to handle GPU and HostDevice migration:
+
+#### Alternative 1
 
 1. The status section of VMI has a field called MigrationState. A new field called TargetDeviceStatus will be added to
    MigrationState struct.
@@ -674,7 +871,7 @@ type MigrationState struct {
 ```
 
 
-### Alternative 2
+#### Alternative 2
 
 In order to handle the live-migration usecase, the following changes are required to the VMI API:
 ```go
@@ -743,6 +940,8 @@ An overview on the approaches used to functional test this design)
   - deletion of VMI will lead to release of resources
   - If GPU clusters are available in CI then e2e tests will be real with a real driver installed
   - If GPU clusters are not available the e2e tests will be mocked
+  - For network devices we will add a new lane with all the current SR-IOV tests with the new API,
+    beside the ones that require migration (this will be added once migration is supported).
 
 ## Implementation Phases
 
@@ -797,3 +996,5 @@ real driver is outside the scope of alpha and will be handled in beta.
   https://kubernetes.io/docs/concepts/scheduling-eviction/dynamic-resource-allocation/
 - NVIDIA DRA driver
   https://github.com/NVIDIA/k8s-dra-driver
+- SR-IOV DRA driver
+  https://github.com/k8snetworkplumbingwg/dra-driver-sriov


### PR DESCRIPTION
### VEP Metadata

First 2 commits are cherry-pick of other PRs.

**Tracking issue**: <!-- For example, https://github.com/kubevirt/enhancements/pull/2 -->
https://github.com/kubevirt/enhancements/issues/10

**SIG label**: <!-- For example, /sig $SIG -->
sig-network

### What this PR does
<!-- Please summarize the VEP update here -->
Extends the DRA devices VEP to document support for DRA-provisioned network
devices, specifically SR-IOV NICs.

Thanks @SchSeba for the co-op, and to all who contributed
See https://github.com/kubevirt/kubevirt/issues/15995

Key additions:
- ResourceClaimNetworkSource API for specifying DRA networks in spec.networks
- SR-IOV integration details: device allocation via DRA, configuration via
  existing KubeVirt networks API.
- Custom MAC address support through `kubevirt.io/dra-network-macs` annotation.
- DRANetworkDevices feature gate (Alpha).
- Example VMI YAML with DRA SR-IOV network configuration.

Network DRA maintains mutual exclusivity with traditional Multus-based SR-IOV
per VM. The existing Multus SR-IOV API remains fully supported and unchanged.

Migration is not included in this stage yet.
It will has its own VEP, more info in the vep.

### Special notes for your reviewer
Didn't include yet about how we detect there is no mix of types (i.e requested SR-IOV and got GPU).
It is still an open issue, mentioned it on the CDI design.
