### PR TITLE
VEP76: Add virt-template-engine repository

### DIFF
--- a/veps/sig-compute/76-vmtemplates/vmtemplate-proposal.md
+++ b/veps/sig-compute/76-vmtemplates/vmtemplate-proposal.md
@@ -783,6 +783,11 @@ in an additional binary called `virttemplatectl`. This binary uses the same
 internal structure as `virtctl`, so in the v1.8.0 cycle, these new commands
 can be imported into `virtctl`.
 
+To enable the import of the template logic developed in the
+`kubevirt/virt-template` repository, the logic is extracted into a
+separate submodule, which is published as `kubevirt.io/virt-template-engine`.
+This requires an additional repository called `kubevirt/virt-template-engine`.
+
 ### template.kubevirt.io/v1beta1
 
 #### Import/Export of VirtualMachineTemplates in standardized format (optional in v1.8.0, full support in v1.9.0)


### PR DESCRIPTION
### VEP Metadata

**Tracking issue**: https://github.com/kubevirt/enhancements/issues/76
**SIG label**: /sig compute

### What this PR does

This adds the kubevirt/virt-template-engine repository in vmtemplate-proposal.md

### Special notes for your reviewer
