### PR TITLE
VEP tamplate: add metadata section for target releases

### DIFF
--- a/veps/NNNN-vep-template/vep.md
+++ b/veps/NNNN-vep-template/vep.md
@@ -29,7 +29,7 @@ Items marked with (R) are required *prior to targeting to a milestone / release*
 ## Overview
 
 <!--
-Provide a brief overview of the topic)
+Provide a brief overview of the topic
 -->
 
 ## Motivation


### PR DESCRIPTION
### What this PR does
This adds a section in the VEP template with target release for each VEP phase (alpha/beta/GA).

With this in place, a PR to update the VEP with the relevant target release must be added as part of the release's design phase.

This will allow the community to plan and discuss the graduation during the planning phase, give a chance to re-assess the graduation requirements, the feature's readiness, etc.

It will ensure that VEPs are not graduated "silently" with a code PR to kubevirt/kubevirt that will bump the phase in-code.

