### PR TITLE
Copy and adjust the feature lifecycle policy from k/community

### DIFF
--- a/docs/feature-lifecycle.md
+++ b/docs/feature-lifecycle.md
@@ -303,7 +303,7 @@ there may be scenarios where the policy described here will not be a fit.
 
 Therefore, it should be acceptable to have exceptions from time to time
 given a very good reasoning and an agreement from 2/3 of the project
-maintainers (also known as "approvers").
+maintainers.
 
 ### Miscellaneous
 


### PR DESCRIPTION
### What this PR does

The complete policy in a human readable format:
https://github.com/iholder101/kubevirt-enhancements/blob/docs/feature-lifecycle/docs/feature-lifecycle.md

**Context**

About a year and a half ago, the feature-lifecycle policy was merged to the kubevirt/community repository.
The policy can be found here: https://github.com/kubevirt/community/blob/main/design-proposals/feature-lifecycle.md.
The PR to introduce it can be found here: https://github.com/kubevirt/community/pull/251.

We have dedicated a lot of energy and time in order to merge this policy. As can be seen, the original PR had **around 400 comments** and took **around 6 months** to merge. If that's not enough, as the PR description says, it was only a follow-up work to a draft version I've made which itself carried many conversations and comments.

The policy was a huge step forward at the time.
However, a lot changed since then. When the proposal was merged, Kubevirt didn't have a structured process for introducing new features other than the vague and now [deprecated design proposal](https://github.com/kubevirt/community/blob/main/design-proposals/README.md). Since then, we have introduced this `kubevirt/enhancements` repository and the VEP process, which was a great step forward, allowing a structured, transparent and inclusive process.

This PR copies the policy to this repository and makes some adjustments to keep it up-to-date according to the VEP process.

**The structure of this PR**

Since the policy was already agreed upon after **huge amount of discussion**, my goal in this PR is to mostly copy it over while making minor changes that we should discuss without re-reviewing the whole policy from scratch.

For this reason, the PR is structured in the following way:
- The first commit (`copy feature-lifecycle.md`) -> copies the policy without any changes.
- The next 3 commits (`remove-*`, `Minor proposal->documentation terminology adjustements`) -> remove out-of-date parts from the original proposal.
- The next commits (`Enhance the feature gate section` and onwards) -> make the actual "interesting" changes.

This structure helps the reviewer focus on **what was changed**, without having to **re-review** the proposal from scratch.