### PR TITLE
VEP 156: Align VEP with #16746 add migration overhead tracking, annotation, and fix bug

### DIFF
--- a/veps/sig-compute/156-vmi-memory-overhead-reporting/vmi-memory-overhead-reporting.md
+++ b/veps/sig-compute/156-vmi-memory-overhead-reporting/vmi-memory-overhead-reporting.md
@@ -1,4 +1,4 @@
-# VEP #156: Expose  Memory Overhead on VMI Status
+# VEP #156: Expose Memory Overhead on VMI Status
 
 ## Release Signoff Checklist
 
@@ -31,15 +31,16 @@ By exposing overhead information:
 - Users can understand actual resource allocation and adjust workloads when needed.
 - External systems, such as autoscalers, monitoring tools, or alerting systems, can track resource overhead and alert or act when VMIs are at risk due to overcommitment or undercommitment.
 - Quotas can use this data to account for virtual resources, considering any memory added or subtracted from the requested values.
+- Fix a hidden bug where virt-handler and metrics collector recalculated memory overhead dynamically, which might lead to using incorrect values after upgrades or configuration changes.
 
 ## Goals
 
 - Expose memory overhead in the `status` of each VMI.
+- Fix incorrect memory overhead calculation in virt-handler and metrics collector after upgrades or configuration changes.
 
 ## Non Goals
 
 - This enhancement does not modify VMI spec or allocation behavior.
-- No changes to VM runtime behavior are included.
 
 ## Definition of Users
 
@@ -87,10 +88,22 @@ https://github.com/kubevirt/kubevirt
 
 ## Design
 
-- Introduce new field in `VMI.status` to report memory overhead.
-- Values will be populated by `virt-controller`.
+- Introduce new fields in `VMI.status` to report memory overhead:
+  - `MemoryOverhead` in `VMI.status.memory` - the memory overhead for the current virt-launcher pod
+  - `TargetMemoryOverhead` in `VMI.status.migrationState` - the memory overhead of the target pod during live migration
+- Add a pod annotation `kubevirt.io/memory-overhead-bytes` on virt-launcher pods to store the overhead per pod.
+  - The annotation is used by external operators such as AAQ because the overhead is static per pod and never changes, whereas the VMI status may temporarily reflect a stale value (e.g. during migration). Reading the annotation from the pod guarantees the correct overhead for that specific pod.
+  - The VMI status fields are used by virt-handler, which does not have a pod informer and cannot read pod annotations directly.
+- Values will be populated by `virt-controller` and `virt-handler`.
 - Overhead values are calculated when the VMI starts and stored in the status.
 - Values are updated again after a live migration completes, reflecting the VMI's current resource allocation.
+
+### Flow
+
+1. `virt-controller` (template.go): calculates overhead, writes the `kubevirt.io/memory-overhead-bytes` pod annotation.
+2. `virt-controller` (lifecycle.go): reads annotation from the pod, sets `status.memory.memoryOverhead`.
+3. `virt-controller` (migration.go): reads annotation from the target pod, sets `status.migrationState.targetMemoryOverhead`.
+4. `virt-handler` (migration-target.go): on migration completion, copies `targetMemoryOverhead` → `status.memory.memoryOverhead`.
 
 ## API Examples
 
@@ -109,10 +122,10 @@ spec:
       limits:
         memory: 6Gi
 status:
-...
   memory:
     memoryOverhead: 300Mi
-...
+  migrationState:
+    targetMemoryOverhead: 320Mi  # during migration, may differ from source
 ```
 
 ## Alternatives
@@ -152,18 +165,22 @@ During an upgrade, the new fields will be added to the VMI status when the featu
 
 # Functional Testing Approach
 
-- Enable the `VMIResourceMetrics` feature gate in functional tests.
-- Verify that `VMI.status.memory.memoryOverhead` and `VMI.status.currentCPUTopology.cpuOverhead` are correctly calculated and reported at VMI startup.
+- Enable the `VmiMemoryOverheadReport` feature gate in functional tests.
+- Verify that the added fields are correctly calculated and reported at VMI startup.
 - Confirm that the values are updated correctly after live migration.
 
 # Implementation History
+
+- 2026-03-01: Alpha implementation merged ([kubevirt/kubevirt#16746](https://github.com/kubevirt/kubevirt/pull/16746))
 
 # Graduation Requirements
 
 ### Alpha
 
-- Implement feature, enable feature gate by default in tests.
-- Add functional tests to verify that `memoryOverhead` and `cpuOverhead` are correctly reported at VMI startup and after live migration.
+- Implement feature behind a feature gate.
+- Add `MemoryOverhead` field to `VMI.status.memory` and `TargetMemoryOverhead` to `VMI.status.migrationState`.
+- Add `kubevirt.io/memory-overhead-bytes` annotation on virt-launcher pods.
+- Add tests to verify that the new fields are correctly reported.
 
 ### Beta
 - revisit the API


### PR DESCRIPTION
Update VEP to reflect the decision made on kubevirt/kubevirt#16746:

- Add TargetMemoryOverhead field for migration tracking
- Add kubevirt.io/memory-overhead-bytes pod annotation
- Add bug fix to goals (incorrect overhead calculation after upgrades)
- Add implementation history

Assisted-by: claude-4.6-opus

### VEP Metadata

**Tracking issue**: https://github.com/kubevirt/enhancements/issues/156
**SIG label**: sig-compute

### What this PR does
<!-- Please summarize the VEP update here -->

### Special notes for your reviewer
