### PR TITLE
VEP #141: Target Beta Graduation for v1.9

### DIFF
--- a/veps/sig-compute/target-xml-mutation-hooks.md
+++ b/veps/sig-compute/target-xml-mutation-hooks.md
@@ -5,14 +5,14 @@
 ### Target releases
 
 - This VEP targets alpha for version: v1.8
-- This VEP targets beta for version:
+- This VEP targets beta for version: v1.9
 - This VEP targets GA for version:
 
 ### Release Signoff Checklist
 
 - [X] (R) Enhancement issue created, which links to VEP dir in [kubevirt/enhancements] (not the initial VEP PR)
 - [x] (R) Alpha target version is explicitly mentioned and approved
-- [ ] (R) Beta target version is explicitly mentioned and approved
+- [x] (R) Beta target version is explicitly mentioned and approved
 - [ ] (R) GA target version is explicitly mentioned and approved
 
 ## Overview
@@ -163,8 +163,7 @@ It should be a scalable and extendable hook system that allows adding new hooks.
 - Add unit tests for hooks.
 
 ### Beta
-- Enable feature gate by default.
-- Migrate all existing XML modifications from source to target-side hooks (dedicated CPU pinning, etc.).
+- Migrate all target-based modifications from source to target-side hooks (dedicated CPU pinning, disk source path for cross-namespace or cross-cluster live migration).
 
 ### GA
 


### PR DESCRIPTION
Remove the requirement to enable it by default, as it is now a global requirement.

### VEP Metadata

**Tracking issue**: 
https://github.com/kubevirt/enhancements/issues/141

**SIG label**: <!-- For example, /sig $SIG -->
/sig sig-compute
 

### What this PR does
<!-- Please summarize the VEP update here -->

### Special notes for your reviewer
