### PR TITLE
VEP 62: Promote to GA

### DIFF
--- a/veps/sig-compute/62-priority queue/migration-prio-queue.md
+++ b/veps/sig-compute/62-priority queue/migration-prio-queue.md
@@ -6,7 +6,7 @@
 
 - This VEP targets alpha for version: v1.7
 - This VEP targets beta for version: v1.8
-- This VEP targets GA for version:
+- This VEP targets GA for version: v1.9
 
 ### Release Signoff Checklist
 
@@ -15,7 +15,7 @@ Items marked with (R) are required *prior to targeting to a milestone / release*
 - [X] (R) Enhancement issue created, which links to VEP dir in [kubevirt/enhancements]
 - [x] (R) Alpha target version is explicitly mentioned and approved
 - [x] (R) Beta target version is explicitly mentioned and approved
-- [ ] (R) GA target version is explicitly mentioned and approved
+- [x] (R) GA target version is explicitly mentioned and approved
 
 ## Overview
 
@@ -136,15 +136,14 @@ type VirtualMachineInstanceMigrationSpec struct {
 ## Feature Lifecycle Phases
 
 ### Alpha
-
 - Add `priority` to VMIM CRD behind a feature gate.
 - Update key controllers and test basic priority ordering.
 - Add feature gate `MigrationPriorityQueue`
 
 ### Beta
+- Enabled by default in e2e tests
 
 ### GA
-
 - Lock feature gate ON
 - Finalize docs
 


### PR DESCRIPTION
### VEP Metadata

**Tracking issue**: https://github.com/kubevirt/enhancements/pull/62
**SIG label**:  /sig compute

### What this PR does
Promote the priority queue to GA.
The whole e2e test suite have been executed with PriorityQueue enabled since 1.8 (and during the deployment phase), 
showing no issue.
We can mark it as GA

### Special notes for your reviewer

/cc @vladikr @jean-edouard @xpivarc 