### PR TITLE
enhancements: add SIG OWNERS files to auto-apply sig labels

### DIFF
--- a/veps/sig-compute/OWNERS
+++ b/veps/sig-compute/OWNERS
@@ -1,0 +1,3 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+labels:
+  - sig/compute

--- a/veps/sig-network/OWNERS
+++ b/veps/sig-network/OWNERS
@@ -1,0 +1,3 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+labels:
+  - sig/network

--- a/veps/sig-storage/OWNERS
+++ b/veps/sig-storage/OWNERS
@@ -1,0 +1,3 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+labels:
+  - sig/storage


### PR DESCRIPTION
### VEP Metadata

**Tracking issue**: N/A
**SIG label**: /sig compute /sig network /sig storage

### What this PR does

Adds `OWNERS` files to each SIG VEP directory (`sig-compute`, `sig-network`, `sig-storage`) so the Prow `owners-label` plugin automatically applies the appropriate `sig/*` label to any PR that touches files under those directories. This removes the manual step of adding `/sig <name>` in the PR description.

### Special notes for your reviewer

No approvers block is set — root `OWNERS` retains merge authority. Labels used: `sig/compute`, `sig/network`, `sig/storage`.