### PR TITLE
Add an "on-by-default readiness" section under beta requirements

### DIFF
--- a/veps/NNNN-vep-template/vep.md
+++ b/veps/NNNN-vep-template/vep.md
@@ -134,4 +134,11 @@ Refer to https://github.com/kubevirt/community/blob/main/design-proposals/featur
 
 ### Beta
 
+#### On-By-Default Readiness
+
+<!--
+Beta features are enabled by default.
+In this section, please specify what needs to be done in order for the VEP to be ready to be enabled by default.
+-->
+
 ### GA


### PR DESCRIPTION
Beta features are being enabled by default.
Add a section to specify the requirements for a VEP in order to be ready to be enabled by default in the Beta stage.