### PR TITLE
VEP-111: postpone graduation to v1.10

### DIFF
--- a/veps/sig-network/ordinal-naming-scheme-upgrade-path.md
+++ b/veps/sig-network/ordinal-naming-scheme-upgrade-path.md
@@ -203,5 +203,8 @@ the mechanism.
 
 ## Graduation
 
-In case no major issues will be reported, the feature gate will be graduated in v1.9.
+Graduation of this feature is dependent on the graduation of [VEP 141](https://github.com/kubevirt/enhancements/issues/141),
+as this VEP relies on the domain mutation hook mechanism introduced by VEP 141.
+
+In case no major issues will be reported, the feature gate will be graduated in v1.10.
 The network domain mutator will be removed in v1.11 concurrently with the remaining logic for the ordinal naming scheme.


### PR DESCRIPTION
### VEP Metadata

**Tracking issue**:  #111 
**SIG label**: /sig network

### What this PR does
This feature cannot graduate to GA before its prerequisite [1] graduates to GA. Since the prerequisite is graduating to Beta in v1.9, the earliest this feature can reach GA is v1.10.

[1] https://github.com/kubevirt/enhancements/issues/141

### Special notes for your reviewer
