### PR TITLE
VEP 115: Promote to Beta

### DIFF
--- a/veps/sig-compute/115-pcie-numa-topology-awareness/pcie-numa-topology-awareness.md
+++ b/veps/sig-compute/115-pcie-numa-topology-awareness/pcie-numa-topology-awareness.md
@@ -4,8 +4,8 @@
 
 ### Target releases
 
-- This VEP targets alpha for version: v1.6
-- This VEP targets beta for version:
+- This VEP targets alpha for version: v1.8
+- This VEP targets beta for version: v1.9
 - This VEP targets GA for version:
 
 ### Release Signoff Checklist
@@ -14,7 +14,7 @@ Items marked with (R) are required *prior to targeting to a milestone / release*
 
 - [x] (R) Enhancement issue created, which links to VEP dir in [kubevirt/enhancements] (not the initial VEP PR)
 - [x] (R) Alpha target version is explicitly mentioned and approved
-- [ ] (R) Beta target version is explicitly mentioned and approved
+- [x] (R) Beta target version is explicitly mentioned and approved
 - [ ] (R) GA target version is explicitly mentioned and approved
 
 ## Overview
@@ -655,7 +655,6 @@ This section will be filled as implementation progresses
 - Evaluate user experience and gather feedback.
 - Turn on feature gate by default.
 - Increase testing coverage if needed.
-- Integrate with Dynamic Resource Allocation (DRA).
 
 ### GA
 


### PR DESCRIPTION
### VEP Metadata

**Tracking issue**: https://github.com/kubevirt/enhancements/pull/115
**SIG label**:  /sig compute

### What this PR does
Graduate PCINumaAwareness to Beta

### Special notes for your reviewer
- Fixed the alpha version on the VEP
- Defer the DRA support to another VEP since DRA for CPU is not ready yet

/cc @vladikr 