### PR TITLE
Add reviewers and approvers to the enhancements repo

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,6 +2,7 @@
 approvers:
   - vladikr
   - xpivarc
+  - iholder101
 reviewers:
   - lyarwood
 


### PR DESCRIPTION
### What this PR does

## Context
I am reducing my day-to-day involvement in the enhancements repo starting June 1st. 
The VEP process currently lacks a formal reviewer list, and we need to ensure continued strong oversight for release check-ins, conflict resolution, and keeping proposals moving.

Our membership policy requires prior reviewer experience before becoming an approver. 
This PR addresses that by first documenting the existing reviewer activity and then using the policy's explicit exception for adding approvers when a repo risks having insufficient coverage.

## Policy Basis
Per https://github.com/kubevirt/community/blob/main/membership_policy.md:

> "In exceptional circumstances, such as when a repo is left without sufficient approvers, the project maintainers can pass a majority vote to add approvers that do not fulfill the requirements."

This situation qualifies due to my upcoming reduced availability.

## Approver Nominations (using exception)
@iholder101 has a strong process orientation with high-quality reviews across multiple VEPs and is well-positioned for this role.

## What Enhancements Approvers Do
As discussed previously, the role in this repo is distinct from core code approvers:

> "The approvers here are responsible for overseeing the VEP process, resolving conflicts when they arise, and guiding proposals toward a resolution. 
It’s not solely about deciding the better technical approach but rather about making sure the process itself doesn’t get stuck, all parties are represented and the design fits the KubeVirt project philosophy. 
We should have no problem proceeding as long as no SIG or root approver raises a strong objection. 
Anyone who wants to become an approver here should be ready to handle exactly these kinds of situations."

New approvers are expected to take responsibility for process health, including helping authors finish work and being ready to revert if needed.
