### PR TITLE
VEP 19: Fix missing GA date

### DIFF
--- a/veps/sig-compute/19-IBM-Z-secure-execution/secure-execution.md
+++ b/veps/sig-compute/19-IBM-Z-secure-execution/secure-execution.md
@@ -7,7 +7,7 @@ Implement support for IBM Z Secure Execution VMs in kubevirt
 
 - This VEP targets alpha for version: v1.6
 - This VEP targets beta for version: v1.7
-- This VEP targets GA for version:
+- This VEP targets GA for version: v1.9
 
 ## Motivation
 To enable customers to deploy secure workloads on their IBM Z machines using kubevirt.


### PR DESCRIPTION
While the GA target and requirements where added to the bottom, the PR missed the updated VEP header.
This happened because the update PR predated the backport of the new template.

Add the missing GA date at the top.

### VEP Metadata

**Tracking issue**: <!-- For example, https://github.com/kubevirt/enhancements/pull/2 --> #19 
**SIG label**: <!-- For example, /sig $SIG --> /sig compute

### What this PR does
<!-- Please summarize the VEP update here -->
Fix missing GA date for VEP 19
### Special notes for your reviewer

GA requirements and target where already added in https://github.com/kubevirt/enhancements/pull/193, but as the PR predated the template update, the target field at the top was missed.