### PR TITLE
VEP 246, 291: remove dependency on #294

### DIFF
--- a/veps/sig-compute/246-migration-compression/migration-compression.md
+++ b/veps/sig-compute/246-migration-compression/migration-compression.md
@@ -47,8 +47,7 @@ bottleneck but not universally beneficial, hence explicit opt-in.
 
 - Expose compression in `MigrationPolicy` under `spec.experimental.compression`
 - Keep the default disabled
-- Gated behind the experimental migration options feature gate defined by
-  [VEP 293](https://github.com/kubevirt/enhancements/pull/295)
+- Gated behind the `AdvancedExperimentalMigrationOptions` feature gate
 - Path toward automatic enablement in future versions
 
 ## Non Goals
@@ -82,9 +81,8 @@ bottleneck but not universally beneficial, hence explicit opt-in.
 ### API and feature gate
 
 Compression is exposed as a field under `spec.experimental` in the
-`MigrationPolicy` CRD. This experimental section,
-its feature gate, and the propagation mechanics are defined by
-[VEP 293: Experimental Migration Options](https://github.com/kubevirt/enhancements/pull/295).
+`MigrationPolicy` CRD. The experimental section is gated by
+`AdvancedExperimentalMigrationOptions` feature gate.
 This VEP only specifies the compression-specific field and its mapping to
 the hypervisor.
 
@@ -156,9 +154,7 @@ The explicit algorithm selection is intended as a transitional API. The
 long-term goal is automatic enablement based on dirty rate, bandwidth, and
 convergence monitoring. If that proves reliable, compression becomes an
 implementation detail and the explicit knob either moves to an
-advanced-only section or is removed. The `spec.experimental` section and
-its lifecycle are defined by
-[VEP 293](https://github.com/kubevirt/enhancements/pull/295).
+advanced-only section or is removed.
 
 ### Consideration for future improvements
 
@@ -211,7 +207,7 @@ overhead is modest at zstd level 1 and bounded by migration bandwidth.
       [VEP 293](https://github.com/kubevirt/enhancements/pull/295)
       (feature gate, `spec.experimental` section, propagation path)
 - [ ] `MigrationCompression` enum and `spec.experimental.compression` field
-      added to `ExperimentalMigrationConfiguration`
+      added to `ExperimentalMigrationConfiguration` within `MigrationPolicy`
 - [ ] `virt-launcher` maps API enum to libvirt compression method and
       sets hypervisor flags
 - [ ] E2E test

--- a/veps/sig-compute/291-dynamic-downtime-tuning/vep.md
+++ b/veps/sig-compute/291-dynamic-downtime-tuning/vep.md
@@ -65,9 +65,8 @@ the existing time-based logic still applies.
 ## Goals
 
 - Activate via presence of `spec.experimental.downtimeTuning` in
-  `MigrationPolicy`, gated behind the experimental migration options
-  feature gate defined by
-  [VEP 293](https://github.com/kubevirt/enhancements/pull/295)
+  `MigrationPolicy`, gated behind the `AdvancedExperimentalMigrationOptions`
+  feature gate
 - Use `maxDowntimeMs` (top-level field per
   [VEP 252](https://github.com/kubevirt/enhancements/pull/252)) as the
   ceiling for the ramp
@@ -106,8 +105,7 @@ kubevirt/kubevirt.
 
 Downtime tuning is activated by the presence of
 `spec.experimental.downtimeTuning` in a `MigrationPolicy`, gated
-behind the experimental migration options feature gate
-([VEP 293](https://github.com/kubevirt/enhancements/pull/295)).
+behind the `AdvancedExperimentalMigrationOptions` feature gate.
 
 The algorithm ramps `max_downtime` up to the `maxDowntimeMs` ceiling —
 a field in `MigrationPolicySpec` / `MigrationConfiguration`.
@@ -311,7 +309,7 @@ For example:
 
 - [ ] `maxDowntimeMs` top-level field available as the ceiling (per
       [VEP 252](https://github.com/kubevirt/enhancements/pull/252))
-- [ ] Experimental options framework from [VEP 293](https://github.com/kubevirt/enhancements/pull/295)
+- [ ] `AdvancedExperimentalMigrationOptions` feature gate
       gates `spec.experimental`
 - [ ] `DowntimeTuningPolicy` struct under `spec.experimental.downtimeTuning`;
       its presence activates the tuning algorithm


### PR DESCRIPTION
### VEP Metadata

**SIG label**: /sig compute

### What this PR does
as discussed on SIG compute mtg, remove references to #294 
