### PR TITLE
VEP 233: Set v1.9.0-beta.0 deadline for dead branch archival

### DIFF
--- a/veps/sig-release/233-release-branch-eol-policy/vep.md
+++ b/veps/sig-release/233-release-branch-eol-policy/vep.md
@@ -253,7 +253,8 @@ To avoid disruption, the following transition plan is proposed:
    N-2 (where N is the current release) are marked EOL simultaneously. As of
    v1.10 GA, this would mean v1.7 and earlier are EOL.
 4. **Archive old branches**: For branches that have been de facto dead for
-   years (release-0.4 through release-0.57), immediately:
+   years (release-0.4 through release-0.57), archive by v1.9.0-beta.0
+   to allow downstream users and vendors a grace period to react:
    - Remove any remaining CI configuration
    - Apply branch protection rules to prevent merges
    - No need to delete branches; they serve as historical record


### PR DESCRIPTION
### VEP Metadata

**Tracking issue**: https://github.com/kubevirt/enhancements/issues/233
**SIG label**: /sig release

### What this PR does

Sets a concrete deadline of v1.9.0-beta.0 (May 21, 2026) for archiving the dead release branches (release-0.4 through release-0.57), replacing the previous "immediately" language in the transition plan.

This gives downstream users and vendors a grace period to react before the branches are locked via https://github.com/kubevirt/project-infra/pull/5041.

### Special notes for your reviewer

This aligns with the announcement being sent to kubevirt-dev@googlegroups.com.