### PR TITLE
VEP #144: draft extension to propagate memlock limit via VMI status

### DIFF
--- a/veps/sig-compute/144-memory-lock-rlimits/memlock-limit-status-extension.md
+++ b/veps/sig-compute/144-memory-lock-rlimits/memlock-limit-status-extension.md
@@ -1,0 +1,155 @@
+# VEP #144 Extension: Propagate computed memlock limit via VMI status
+
+*Draft for discussion -- extends the existing VEP #144 (Memory Lock RLimit configuration)*
+
+> **Note:** This draft assumes [kubevirt/kubevirt#17805](https://github.com/kubevirt/kubevirt/pull/17805) (VFIO memlock scaling in virt-handler) and [kubevirt/kubevirt#17857](https://github.com/kubevirt/kubevirt/pull/17857) (shared `pkg/vfio` package and `<memtune><hard_limit>` in domain XML) have merged. #17805 is under review; #17857 is a draft dependent on it. The assumptions about `pkg/vfio`, `CountDevices()`, `CalculateMemlockLimit()`, and `<memtune><hard_limit>` support in the domain converter all come from these PRs.
+
+## Problem
+
+The memlock rlimit value is currently computed independently in multiple places:
+
+- **virt-handler** (`CalculateMemlockSize()`) -- for prlimit64 on the QEMU process
+- **virt-launcher** (domain converter) -- for `<memtune><hard_limit>` in the domain XML
+- **libvirt** (`qemuDomainGetMemLockLimitBytes()`) -- its own internal calculation
+
+These calculations can drift out of sync. Additionally, the inputs that determine the memlock value come from multiple sources:
+
+- Automatic VFIO device counting (GPUs, HostDevices, SRIOV) -- internally computed
+- VEP #144's `reservedOverhead.addedOverhead` -- user or webhook specified
+- VEP #144's `reservedOverhead.memLock` flag -- signals locking is required
+- Future sources (new device types, platform-specific requirements)
+
+There is no single place where the final memlock value is computed and no mechanism to propagate it to all consumers.
+
+## Proposal
+
+Add a **status-only** field `memLockLimit` to `MemoryStatus`. The value is computed once by virt-controller and consumed by both virt-handler and virt-launcher. No VMI spec changes.
+
+### New status field
+
+```go
+type MemoryStatus struct {
+    GuestAtBoot    *resource.Quantity `json:"guestAtBoot,omitempty"`
+    GuestCurrent   *resource.Quantity `json:"guestCurrent,omitempty"`
+    GuestRequested *resource.Quantity `json:"guestRequested,omitempty"`
+    MemoryOverhead *resource.Quantity `json:"memoryOverhead,omitempty"`
+    MemLockLimit   *resource.Quantity `json:"memLockLimit,omitempty"`
+}
+```
+
+### Compute-once flow
+
+```
+virt-controller
+  │
+  ├─ Inputs:
+  │    - VFIO device count from VMI spec (vfio.CalculateMemlockLimit)
+  │    - reservedOverhead.addedOverhead (VEP #144)
+  │    - reservedOverhead.memLock flag (VEP #144)
+  │    - Future: platform-specific overrides
+  │
+  └─ Writes vmi.Status.Memory.MemLockLimit
+       │
+       ├─ virt-handler reads → prlimit64 on QEMU process
+       │
+       └─ virt-launcher reads (via SyncVirtualMachine gRPC)
+            → <memtune><hard_limit> in domain XML
+```
+
+No pod annotation is needed. Unlike `MemoryOverheadAnnotationBytes` (which the pod needs at creation time for resource requests), the memlock value is consumed at runtime: virt-handler reads it from VMI status before the domain starts, and virt-launcher receives the full VMI object via gRPC.
+
+### How this unifies both approaches
+
+| Source | Triggers | Current path | With this extension |
+| :----- | :------- | :----------- | :------------------ |
+| VFIO devices (auto) | KubeVirt counts devices internally | Parallel calc in handler + launcher | Controller computes, writes to status |
+| `addedOverhead` (VEP #144) | User/webhook sets spec field | Flows into `GetMemoryOverhead()`, inflates pod request | Feeds controller's memlock calc, writes to status. Pod request handled separately. |
+| `memLock: Required` (VEP #144) | User/webhook sets flag | Triggers handler's memlock adjustment | Triggers controller to compute and write to status |
+
+The VMI spec fields (`addedOverhead`, `memLock`) remain as inputs -- they express user intent. The computed result lives only in status.
+
+### Memlock calculation in virt-controller
+
+```go
+func calculateMemLockLimit(vmi *v1.VirtualMachineInstance) *resource.Quantity {
+    // Start with automatic VFIO calculation
+    memlockBytes := vfio.CalculateMemlockLimit(vmi)
+
+    // Add user-specified overhead from VEP #144
+    if vmi.Spec.Domain.Memory != nil &&
+       vmi.Spec.Domain.Memory.ReservedOverhead != nil &&
+       vmi.Spec.Domain.Memory.ReservedOverhead.AddedOverhead != nil {
+        memlockBytes += vmi.Spec.Domain.Memory.ReservedOverhead.AddedOverhead.Value()
+    }
+
+    if memlockBytes == 0 {
+        // Check if memLock is explicitly required without devices
+        if util.RequiresLockingMemory(vmi) {
+            // Base memlock: guestMemory + standard overhead
+            memlockBytes = vfio.GetVirtualMemoryBytes(vmi) + vfio.MMIOOverheadBytes
+        }
+    }
+
+    if memlockBytes == 0 {
+        return nil
+    }
+    q := resource.NewQuantity(memlockBytes, resource.BinarySI)
+    return q
+}
+```
+
+### Consumer changes
+
+**virt-handler** `AdjustResources()`:
+
+```
+1. Read vmi.Status.Memory.MemLockLimit (new)
+2. Fall back to vmi.Status.MigrationState.TargetMemoryOverhead (existing, migration)
+3. Fall back to local GetMemoryOverhead() calculation (existing, legacy)
+```
+
+**virt-launcher** `MemoryConfigurator.configureMemLock()`:
+
+```
+1. Read vmi.Status.Memory.MemLockLimit → set <memtune><hard_limit>
+2. Fall back to vfio.CalculateMemlockLimit(vmi) (existing, for when status not yet populated)
+```
+
+## Impact on VEP #144
+
+### No breaking changes
+
+- `reservedOverhead.addedOverhead` continues to work as an input
+- `reservedOverhead.memLock` continues to trigger memlock adjustment
+- Existing behaviour preserved when `MemLockLimit` status field is absent
+
+### Improvement: decoupled from pod sizing
+
+Currently `addedOverhead` flows into `GetMemoryOverhead()` which inflates both the pod memory request and the memlock rlimit. With this extension, virt-controller can compute the memlock value separately from the pod sizing. `addedOverhead` could be split into:
+
+- Its contribution to pod memory request (for actual memory consumption)
+- Its contribution to the memlock limit (for VFIO address space ceiling)
+
+This aligns with the VEP's stated goal: "Adjust memory lock limits **without impacting VMI scheduling capacity**."
+
+## Benefits
+
+- **Single source of truth** -- memlock value computed once, consumed everywhere
+- **No parallel calculations** -- eliminates drift between handler, launcher, and libvirt
+- **Status-only** -- no VMI spec changes, no VEP needed for the status field
+- **Backwards compatible** -- consumers fall back to existing behaviour when status field absent
+- **Extensible** -- future memlock inputs feed into the same controller calculation
+- **Decouples memlock from pod sizing** -- addresses VEP #144's stated goal
+
+## Prior work
+
+This extension builds on two PRs that address the immediate multi-device VFIO memlock problem in v1.9:
+
+- [kubevirt/kubevirt#17805](https://github.com/kubevirt/kubevirt/pull/17805) -- scales virt-handler's memlock rlimit for multi-device VFIO passthrough. Extracts `CalculateMemlockSize()` and introduces `CountVFIODevices()` in `pkg/util`.
+- [kubevirt/kubevirt#17857](https://github.com/kubevirt/kubevirt/pull/17857) -- extracts the VFIO memlock formula into a shared `pkg/vfio` package and sets `<memtune><hard_limit>` in the domain XML so libvirt uses KubeVirt's value directly.
+
+These PRs solve the problem for v1.9 by sharing the formula between handler and launcher via `pkg/vfio`. This extension replaces the shared formula approach with a single computation in virt-controller propagated via VMI status, eliminating parallel calculations entirely.
+
+## Timeline
+
+- v1.10: Introduce `MemLockLimit` status field and controller computation. Refactor `addedOverhead` to stop flowing into `GetMemoryOverhead()` for memlock. Remove fallback calculations from handler and launcher. Consumers read exclusively from `vmi.Status.Memory.MemLockLimit`.

--- a/veps/sig-compute/144-memory-lock-rlimits/memlock-limit-status-extension.md
+++ b/veps/sig-compute/144-memory-lock-rlimits/memlock-limit-status-extension.md
@@ -2,7 +2,7 @@
 
 *Draft for discussion -- extends the existing VEP #144 (Memory Lock RLimit configuration)*
 
-> **Note:** This draft assumes [kubevirt/kubevirt#17805](https://github.com/kubevirt/kubevirt/pull/17805) (VFIO memlock scaling in virt-handler) and [kubevirt/kubevirt#17857](https://github.com/kubevirt/kubevirt/pull/17857) (shared `pkg/vfio` package and `<memtune><hard_limit>` in domain XML) have merged. #17805 is under review; #17857 is a draft dependent on it. The assumptions about `pkg/vfio`, `CountDevices()`, `CalculateMemlockLimit()`, and `<memtune><hard_limit>` support in the domain converter all come from these PRs.
+> **Note:** [kubevirt/kubevirt#17805](https://github.com/kubevirt/kubevirt/pull/17805) (VFIO memlock scaling in virt-handler) has merged. This draft also assumes [kubevirt/kubevirt#17857](https://github.com/kubevirt/kubevirt/pull/17857) (shared `pkg/vfio` package and `<memtune><hard_limit>` in domain XML) will merge. #17857 is a draft dependent on #17805. The assumptions about `pkg/vfio`, `CountDevices()`, `CalculateMemlockLimit()`, and `<memtune><hard_limit>` support in the domain converter come from these PRs.
 
 ## Problem
 
@@ -75,15 +75,17 @@ func calculateMemLockLimit(vmi *v1.VirtualMachineInstance) *resource.Quantity {
     // Start with automatic VFIO calculation
     memlockBytes := vfio.CalculateMemlockLimit(vmi)
 
-    // Add user-specified overhead from VEP #144
+    // Add user-specified overhead from VEP #144 when memlock is required
     if vmi.Spec.Domain.Memory != nil &&
-       vmi.Spec.Domain.Memory.ReservedOverhead != nil &&
-       vmi.Spec.Domain.Memory.ReservedOverhead.AddedOverhead != nil {
-        memlockBytes += vmi.Spec.Domain.Memory.ReservedOverhead.AddedOverhead.Value()
+       vmi.Spec.Domain.Memory.ReservedOverhead != nil {
+        if vmi.Spec.Domain.Memory.ReservedOverhead.MemLock == v1.MemLockRequired &&
+           vmi.Spec.Domain.Memory.ReservedOverhead.AddedOverhead != nil {
+            memlockBytes += vmi.Spec.Domain.Memory.ReservedOverhead.AddedOverhead.Value()
+        }
     }
 
     if memlockBytes == 0 {
-        // Check if memLock is explicitly required without devices
+        // Check if memLock is explicitly required without VFIO devices
         if util.RequiresLockingMemory(vmi) {
             // Base memlock: guestMemory + standard overhead
             memlockBytes = vfio.GetVirtualMemoryBytes(vmi) + vfio.MMIOOverheadBytes
@@ -131,6 +133,25 @@ Currently `addedOverhead` flows into `GetMemoryOverhead()` which inflates both t
 - Its contribution to the memlock limit (for VFIO address space ceiling)
 
 This aligns with the VEP's stated goal: "Adjust memory lock limits **without impacting VMI scheduling capacity**."
+
+### Example: 2x GPU passthrough with 8Gi guest memory
+
+Consider a VM with 2 NVIDIA GPUs (each with 64Gi BAR), 8Gi guest memory, and `addedOverhead: 128Gi`:
+
+| Value | Current (unified) | With this extension |
+| :---- | :----------------- | :------------------ |
+| Pod memory request | `GetMemoryOverhead()` + 8Gi + 128Gi ≈ **137Gi** | `GetMemoryOverhead()` + 8Gi ≈ **9Gi** |
+| Memlock rlimit | Same ~137Gi (from `GetMemoryOverhead()`) | `MemLockLimit`: 8Gi guest + 1Gi MMIO + 8Gi scaling + 128Gi added = **145Gi** |
+
+Today the 128Gi `addedOverhead` inflates the pod memory request to ~137Gi, wasting ~128Gi of schedulable memory capacity per VM. The node must have 137Gi free to schedule the pod, even though real memory consumption is ~9Gi. With this extension, the pod requests only what it actually consumes, while the memlock limit is sized independently for the VFIO address space ceiling.
+
+### Safety: memlock vs cgroup limits
+
+The original VEP #144 discussion raised a valid concern: if a process locks more memory than its cgroup allows, the kubelet will OOM-kill the pod. This concern was specific to legacy VFIO type1, where the kernel physically pins all IOVA-mapped pages.
+
+With iommufd replacing type1 for modern deployments, the memlock rlimit becomes an address space ceiling rather than a physical memory commitment. The kernel no longer pins all mapped pages into physical RAM, so the memlock limit can safely exceed the pod's cgroup memory limit without triggering OOM kills.
+
+For legacy type1, multi-device vIOMMU passthrough was already broken before [#17805](https://github.com/kubevirt/kubevirt/pull/17805) due to insufficient rlimits -- the cgroup sizing gap was latent, not newly introduced. This extension makes that gap explicit and fixable: the controller could factor in the IOMMU backend when deciding whether `addedOverhead` should also inflate the pod request.
 
 ## Benefits
 


### PR DESCRIPTION
### VEP Metadata

**Tracking issue**: https://github.com/kubevirt/enhancements/issues/144
**SIG label**: /sig compute

### What this PR does

Adds a draft proposal to extend VEP #144 (Memory Lock RLimit configuration) with a `MemLockLimit` status field on `MemoryStatus`.

Currently the memlock rlimit value is computed independently in virt-handler (for prlimit64) and virt-launcher (for domain XML `<memtune><hard_limit>`). This extension proposes computing it once in virt-controller and propagating via `vmi.Status.Memory.MemLockLimit`, eliminating parallel calculations.

This also addresses the gap between VEP #144's stated goal ("adjust memory lock limits **without impacting VMI scheduling capacity**") and the current implementation where `addedOverhead` flows into `GetMemoryOverhead()`, inflating pod memory requests.

### Key points

- **Status-only** -- no VMI spec changes, `addedOverhead` and `memLock` remain as inputs
- **Compute-once** -- virt-controller computes the final value from all inputs (VFIO device count, `addedOverhead`, `memLock` flag)
- **Decoupled from pod sizing** -- memlock limit does not inflate pod memory requests
- **Backwards compatible** -- consumers fall back to existing behaviour when status field absent

### Prior work

Builds on:
- kubevirt/kubevirt#17805 -- VFIO memlock scaling in virt-handler
- kubevirt/kubevirt#17857 -- shared `pkg/vfio` package and `<memtune><hard_limit>` in domain XML

### Timeline

- v1.10