### PR TITLE
VEP 143: Update feature gate name to VMStatsCollector

### DIFF
--- a/veps/sig-observability/monitoring-stack-separation.md
+++ b/veps/sig-observability/monitoring-stack-separation.md
@@ -493,7 +493,7 @@ Refer to https://github.com/kubevirt/community/blob/main/design-proposals/featur
 
 ### Alpha
 
-- [ ] Feature gate `MonitoringStackSeparation` guards KubeVirt-side code changes
+- [ ] Feature gate `VMStatsCollector` guards KubeVirt-side code changes
   (gRPC refactor in `virt-handler`/`virt-launcher`)
 - [ ] `GetVMStats` RPC implemented in `virt-launcher` and called by `virt-handler`
   with fallback to legacy RPCs


### PR DESCRIPTION
### VEP Metadata

Tracking issue: https://github.com/kubevirt/enhancements/issues/143
SIG label: sig-observability

### What this PR does
VEP 143: Update feature gate name to VMStatsCollector

### Special notes for your reviewer
https://github.com/kubevirt/kubevirt/pull/17550#discussion_r3298399337