### PR TITLE
VEP 291 & VEP 246: Removed VEP 293 reference

### DIFF
--- a/veps/sig-compute/246-migration-compression/migration-compression.md
+++ b/veps/sig-compute/246-migration-compression/migration-compression.md
@@ -47,8 +47,7 @@ bottleneck but not universally beneficial, hence explicit opt-in.
 
 - Expose compression in `MigrationPolicy` under `spec.experimental.compression`
 - Keep the default disabled
-- Gated behind the experimental migration options feature gate defined by
-  [VEP 293](https://github.com/kubevirt/enhancements/pull/295)
+- Exposed via `MigrationPolicy.spec.experimental` (not the KubeVirt CR); enabled per policy by setting `compression: zstd`
 - Path toward automatic enablement in future versions
 
 ## Non Goals
@@ -79,14 +78,9 @@ bottleneck but not universally beneficial, hence explicit opt-in.
 
 ## Design
 
-### API and feature gate
+### API
 
-Compression is exposed as a field under `spec.experimental` in the
-`MigrationPolicy` CRD. This experimental section,
-its feature gate, and the propagation mechanics are defined by
-[VEP 293: Experimental Migration Options](https://github.com/kubevirt/enhancements/pull/295).
-This VEP only specifies the compression-specific field and its mapping to
-the hypervisor.
+Compression is exposed under `MigrationPolicy.spec.experimental`, a temporary section available only on `MigrationPolicy` (not the KubeVirt CR). Resolved options are merged into per-VMIM configuration. This VEP only specifies the compression-specific field and its mapping to the hypervisor.
 
 The compression field is a string enum: `"none"` (disabled) or `"zstd"`.
 When omitted (`nil`) or set to `"none"`, compression is disabled.
@@ -156,9 +150,7 @@ The explicit algorithm selection is intended as a transitional API. The
 long-term goal is automatic enablement based on dirty rate, bandwidth, and
 convergence monitoring. If that proves reliable, compression becomes an
 implementation detail and the explicit knob either moves to an
-advanced-only section or is removed. The `spec.experimental` section and
-its lifecycle are defined by
-[VEP 293](https://github.com/kubevirt/enhancements/pull/295).
+advanced-only section or is removed. The `spec.experimental` section is removed before GA.
 
 ### Consideration for future improvements
 
@@ -197,7 +189,7 @@ overhead is modest at zstd level 1 and bounded by migration bandwidth.
    params include `Compression: "zstd"` when enabled.
 2. **E2E**: Migration succeeds with compression; verify non-zero compression
    bytes in job stats.
-3. **Negative**: `spec.experimental` ignored when gate is disabled.
+3. **Negative**: `compression: none` or omitted leaves compression disabled.
 
 ## Implementation History
 
@@ -207,11 +199,9 @@ overhead is modest at zstd level 1 and bounded by migration bandwidth.
 
 ### Alpha
 
-- [ ] Experimental migration options framework from
-      [VEP 293](https://github.com/kubevirt/enhancements/pull/295)
-      (feature gate, `spec.experimental` section, propagation path)
+- [ ] `MigrationPolicy.spec.experimental` propagation path
 - [ ] `MigrationCompression` enum and `spec.experimental.compression` field
-      added to `ExperimentalMigrationConfiguration`
+      added to `ExperimentalMigrationOptions`
 - [ ] `virt-launcher` maps API enum to libvirt compression method and
       sets hypervisor flags
 - [ ] E2E test

--- a/veps/sig-compute/291-dynamic-downtime-tuning/vep.md
+++ b/veps/sig-compute/291-dynamic-downtime-tuning/vep.md
@@ -64,10 +64,7 @@ the existing time-based logic still applies.
 
 ## Goals
 
-- Activate via presence of `spec.experimental.downtimeTuning` in
-  `MigrationPolicy`, gated behind the experimental migration options
-  feature gate defined by
-  [VEP 293](https://github.com/kubevirt/enhancements/pull/295)
+- Activate via presence of `spec.experimental.downtimeTuning` in `MigrationPolicy`
 - Use `maxDowntimeMs` (top-level field per
   [VEP 252](https://github.com/kubevirt/enhancements/pull/252)) as the
   ceiling for the ramp
@@ -102,12 +99,10 @@ kubevirt/kubevirt.
 
 ## Design
 
-### API and feature gate
+### API
 
 Downtime tuning is activated by the presence of
-`spec.experimental.downtimeTuning` in a `MigrationPolicy`, gated
-behind the experimental migration options feature gate
-([VEP 293](https://github.com/kubevirt/enhancements/pull/295)).
+`spec.experimental.downtimeTuning` in a `MigrationPolicy`.
 
 The algorithm ramps `max_downtime` up to the `maxDowntimeMs` ceiling —
 a field in `MigrationPolicySpec` / `MigrationConfiguration`.
@@ -295,7 +290,7 @@ per step. No new API resources or watches.
    absent. Ceiling respected.
 2. **E2E**: Migration with tuning enabled + moderately dirty workload.
    Verify successful completion and log lines showing downtime steps. In constrained environment it won't be possible to reliably reach a fixed downtime estimate, excessive non-default values would need to be used.
-3. **Negative**: `spec.experimental` ignored when gate is disabled.
+3. **Negative**: `spec.experimental.downtimeTuning` absent → no-op.
 
 ## Implementation History
 
@@ -311,8 +306,7 @@ For example:
 
 - [ ] `maxDowntimeMs` top-level field available as the ceiling (per
       [VEP 252](https://github.com/kubevirt/enhancements/pull/252))
-- [ ] Experimental options framework from [VEP 293](https://github.com/kubevirt/enhancements/pull/295)
-      gates `spec.experimental`
+- [ ] `MigrationPolicy.spec.experimental` propagation path
 - [ ] `DowntimeTuningPolicy` struct under `spec.experimental.downtimeTuning`;
       its presence activates the tuning algorithm
 - [ ] `virt-launcher` runs tuning algorithm in monitoring loop


### PR DESCRIPTION
VEP 293 was considered redundant and closed. Since it never merged, it doesn't make sense to reference it in an approved VEP.