### PR TITLE
VEP #233: Rework to use dedicated release branch maintainer groups

### DIFF
--- a/veps/sig-release/233-release-branch-eol-policy/vep.md
+++ b/veps/sig-release/233-release-branch-eol-policy/vep.md
@@ -32,9 +32,20 @@ to a situation where CVE fixes, dependency updates, and other backports must be
 applied to an ever-growing number of branches, consuming significant
 contributor time and CI resources.
 
-This VEP proposes adopting a hard EOL policy modeled on the
-[Kubernetes patch release support period](https://kubernetes.io/releases/patch-releases/#support-period),
-limiting active maintenance to the **3 most recent minor releases**.
+Additionally, the same core maintainers who develop features on `main` are
+responsible for reviewing backports across all release branches. This creates
+reviewer fatigue and concentrates the maintenance burden on a small group of
+individuals — a problem that grows with each new release regardless of how many
+old branches are archived.
+
+This VEP proposes a **dedicated release branch governance model** where all
+release branches, from the point they are cut, are owned by maintainer groups
+separate from the core `main` branch maintainers. Release branches remain
+active as long as their dedicated maintainers opt in to keep them alive, and
+transition to EOL when no maintainer is willing to continue. This is modeled
+on [OpenStack's stable branch policy](https://docs.openstack.org/project-team-guide/stable-branches.html),
+which has operated at this scale (15+ project teams, dozens of repos) for over
+a decade.
 
 ## Motivation
 
@@ -45,10 +56,12 @@ only formally tracks v1.2 through v1.7 (with v1.2-v1.4 already marked EOL),
 in practice backports continue to land on branches well beyond the documented
 support window.
 
+### CVE Backport Burden
+
 Recent CVE responses illustrate how the lack of an enforced EOL compounds
 the maintenance burden:
 
-### CVE-2023-39325 / CVE-2023-44487 — HTTP/2 Rapid Reset (Oct 2023, High)
+#### CVE-2023-39325 / CVE-2023-44487 — HTTP/2 Rapid Reset (Oct 2023, High)
 
 This high-severity vulnerability in `golang.org/x/net` and
 `google.golang.org/grpc` required backports to **7 branches**: `release-0.49`,
@@ -61,11 +74,14 @@ and `release-1.2`
 [#10675](https://github.com/kubevirt/kubevirt/pull/10675),
 [#10674](https://github.com/kubevirt/kubevirt/pull/10674),
 [#10673](https://github.com/kubevirt/kubevirt/pull/10673)).
-Under a 3-release policy, only 3 branches (1.0, 1.1, 1.2) would have been
-in scope. Notably, `release-0.49` targeted Kubernetes 1.24, which had already
-been EOL for months when the fix landed.
+Under a maintainer-driven model, responsibility for these backports would
+have been distributed across dedicated release branch maintainers rather than
+falling on core `main` branch reviewers. Notably, `release-0.49` targeted
+Kubernetes 1.24, which had already been EOL for months when the fix landed —
+a branch that would likely have reached EOL earlier if maintainer opt-in were
+required to keep it alive.
 
-### CVE-2024-21626 — runc Container Escape (Jan 2024, Critical)
+#### CVE-2024-21626 — runc Container Escape (Jan 2024, Critical)
 
 This critical container escape vulnerability required backports to
 **4 branches**: `release-0.58`, `release-0.59`, `release-1.0`, and
@@ -77,7 +93,7 @@ This critical container escape vulnerability required backports to
 `release-0.58` targeted Kubernetes 1.26, which was well past its own EOL when
 the fix was merged.
 
-### CVE-2025-22869 — golang.org/x/crypto SSH Handshake Panic (2025, High)
+#### CVE-2025-22869 — golang.org/x/crypto SSH Handshake Panic (2025, High)
 
 A panic-triggering vulnerability in the Go SSH handshake was backported to
 `release-1.3` and `release-1.4`
@@ -85,25 +101,53 @@ A panic-triggering vulnerability in the Go SSH handshake was backported to
 [#14629](https://github.com/kubevirt/kubevirt/pull/14629)),
 both of which are already marked EOL in the sig-release support matrix.
 
-### CVE-2025-47913 — golang.org/x/crypto Denial of Service (2025, High)
+#### CVE-2025-47913 — golang.org/x/crypto Denial of Service (2025, High)
 
 A denial-of-service vulnerability in Go's crypto library was backported to
 `release-1.5` and `release-1.6`
 ([#16887](https://github.com/kubevirt/kubevirt/pull/16887),
 [#16870](https://github.com/kubevirt/kubevirt/pull/16870)).
 
-### CVE Backport Scope Comparison
+#### CVE Backport Summary
 
-| CVE | Date | Severity | Branches Backported | Under 3-Release Policy |
-|-----|------|----------|--------------------:|---------------------:|
-| CVE-2023-39325 | Oct 2023 | High | 7 | 3 |
-| CVE-2024-21626 | Jan 2024 | Critical | 4 | 3 |
-| CVE-2025-22869 | 2025 | High | 2 | 2 |
-| CVE-2025-47913 | 2025 | High | 2 | 2 |
+| CVE | Date | Severity | Branches Backported |
+|-----|------|----------|--------------------:|
+| CVE-2023-39325 | Oct 2023 | High | 7 |
+| CVE-2024-21626 | Jan 2024 | Critical | 4 |
+| CVE-2025-22869 | 2025 | High | 2 |
+| CVE-2025-47913 | 2025 | High | 2 |
 
-The pattern is clear: without an enforced EOL, each CVE response requires
-work across an unpredictable and growing set of branches. This creates
-several compounding problems:
+Under this VEP's governance model, the review and CI burden for these
+backports would be carried by dedicated release branch maintainers rather
+than core `main` branch reviewers. Branches without active maintainers
+would have already transitioned to EOL, naturally reducing the scope.
+
+### Reviewer Burden
+
+The unbounded branch count is only part of the problem. The same core
+maintainers who review feature work on `main` also review every backport
+cherry-pick across all release branches. This creates compounding reviewer
+fatigue:
+
+- Approximately **half of all upstream PRs are backports** — from various
+  contributors and downstream vendors — creating significant reviewer and CI
+  load
+- Individual core maintainers report spending **up to half of their review
+  time** on backports rather than feature development
+- Backports are often a source of long-running fixes where old branches are
+  discovered to be non-functional
+- Fixes for customer problems are sometimes raised upstream but never
+  backported, with missing bug tracking and no follow-up
+- Backports are sometimes raised for CVEs that don't actually affect upstream
+- Edge cases with forked dependencies (e.g.
+  [kubevirt#17692](https://github.com/kubevirt/kubevirt/pull/17692)) require
+  time-consuming manual verification by maintainers
+
+### Summary
+
+The pattern is clear: without separating release branch maintenance from core
+development and without a mechanism to EOL branches that lack active
+maintainers, the project faces:
 
 1. **Unsustainable contributor burden**: Each CVE or critical fix must be
    backported, reviewed, and merged across many branches. The HTTP/2 rapid
@@ -112,27 +156,30 @@ several compounding problems:
 2. **Unbounded CI cost**: CI lanes must be maintained and executed for every
    active release branch. Old branches frequently break due to infrastructure
    drift, consuming debugging time unrelated to the fix itself.
-3. **False sense of security**: Users on ancient releases receive sporadic CVE
+3. **Reviewer fatigue**: Core maintainers context-switch between feature
+   reviews on `main` and backport reviews across release branches, with
+   backports consuming up to half their review bandwidth.
+4. **False sense of security**: Users on ancient releases receive sporadic CVE
    fixes but no guarantee of comprehensive coverage, creating a false sense
    that the release is fully maintained.
-4. **No upgrade incentive**: Without a hard EOL, downstream consumers have no
+5. **No upgrade incentive**: Without a hard EOL, downstream consumers have no
    forcing function to upgrade to supported releases.
-5. **Inconsistency with stated policy**: The documentation already ties EOL to
+6. **Inconsistency with stated policy**: The documentation already ties EOL to
    Kubernetes support periods, but the lack of enforcement makes the policy
    meaningless in practice. Fixes are landing on branches targeting Kubernetes
    versions that Kubernetes itself stopped supporting long ago.
 
 ## Goals
 
-- Define a hard EOL policy for KubeVirt release branches with a fixed support
-  window
-- Align the KubeVirt release lifecycle with the Kubernetes release support
-  model
-- Reduce the number of actively maintained release branches to a bounded,
-  predictable set
+- Separate release branch maintenance from core `main` branch development by
+  establishing dedicated release branch maintainer groups
+- Define a maintainer-driven EOL policy where branches transition to EOL when
+  no dedicated maintainer opts in to keep them alive
 - Establish automated enforcement of EOL through CI and branch protection
 - Provide a clear transition plan for the existing backlog of unmaintained
   branches
+- Create a contributor onboarding path through release branch review toward
+  full SIG approver status on `main`
 
 ## Non Goals
 
@@ -148,30 +195,44 @@ several compounding problems:
 
 - **KubeVirt release maintainers**: Contributors who cut releases, manage CI
   lanes, and process backport PRs
+- **Release branch maintainers**: Dedicated reviewers/approvers responsible for
+  backport review and CI health on release branches, separate from core `main`
+  branch maintainers
 - **KubeVirt contributors**: Developers who must create and shepherd cherry-pick
   PRs for bug fixes and CVEs
-- **Downstream distributors**: Organizations (e.g., Red Hat, SUSE) that
-  consume KubeVirt releases and may maintain their own extended support windows
-  independently
+- **Downstream distributors**: Organizations that consume KubeVirt releases
+  and may maintain their own extended support windows independently
 - **End users**: Operators running KubeVirt clusters who need to understand
   which versions receive security and bug fixes
 
 ## User Stories
 
-- As a **release maintainer**, I want a bounded number of release branches to
-  maintain so that CVE response does not require cherry-picks to 10+ branches.
+- As a **release maintainer**, I want release branches to have dedicated
+  maintainers and a clear EOL process so that unmaintained branches are
+  retired and do not accumulate indefinitely.
+- As a **core maintainer**, I want release branch review to be handled by a
+  dedicated group so that I can focus my review time on feature development on
+  `main`.
+- As a **release branch maintainer**, I want clear ownership of specific
+  release branches so that I know what I am responsible for and can build
+  expertise in the backporting process.
+- As a **new contributor**, I want a structured path into the project where I
+  can start with lower-risk backport reviews and work toward full SIG approver
+  status on `main`.
 - As a **contributor**, I want a clear policy on which branches accept
-  backports so that I do not waste time preparing cherry-picks for unsupported
+  backports so that I do not waste time preparing cherry-picks for EOL
   releases.
-- As a **downstream distributor**, I want a predictable upstream EOL schedule
-  so that I can plan my own support lifecycle accordingly.
-- As an **end user**, I want to know exactly which KubeVirt versions are
-  supported so that I can plan upgrades within the support window.
+- As a **downstream distributor**, I want release branches to remain active
+  upstream as long as I am willing to provide maintainers, so that I do not
+  need to maintain private forks unnecessarily.
+- As an **end user**, I want to know exactly which KubeVirt versions have
+  active maintainers so that I can plan upgrades accordingly.
 
 ## Repos
 
 - [kubevirt/kubevirt](https://github.com/kubevirt/kubevirt) — release branch
-  management, branch protection, documentation updates
+  management, branch protection, OWNERS/OWNERS_ALIASES updates, documentation
+  updates
 - [kubevirt/sig-release](https://github.com/kubevirt/sig-release) — support
   matrix updates, release schedule documentation
 - [kubevirt/project-infra](https://github.com/kubevirt/project-infra) — CI
@@ -179,35 +240,47 @@ several compounding problems:
 
 ## Design
 
-### Support Window
+### Branch Lifecycle
 
-KubeVirt will support the **3 most recent minor releases**. With 3 minor
-releases per year (~every 15 weeks), this provides a support window of
-approximately **12-15 months** per release — closely matching the Kubernetes
-support period of ~14 months.
+A release branch progresses through three phases:
+
+| Phase | Ownership | CI | Upstream Obligation |
+|-------|-----------|-----|---------------------|
+| **Active** | Dedicated release branch maintainers | Full Prow presubmit + periodic | Maintainers actively review backports and monitor CI |
+| **Maintainer opt-in review** | Same, subject to re-confirmation | Maintained by opt-in party | Branch stays alive only if a maintainer explicitly opts in |
+| **End of Life** | None | Removed | Branch archived, no further merges |
 
 | Aspect | Current Policy | Proposed Policy |
 |--------|---------------|-----------------|
-| Supported releases | Unbounded ("not enforced") | 3 most recent minor releases |
-| Max active branches | 8-13+ for CVEs | 3 (plus main) |
-| EOL enforcement | Soft/optional | Hard cutoff |
-| CVE backport scope | All "willing" branches | 3 releases |
-| Support window | Indefinite | ~12-15 months |
+| Supported releases | Unbounded ("not enforced") | Maintainer-driven: active as long as someone opts in |
+| EOL enforcement | Soft/optional | Hard: absence of maintainers = automatic EOL |
+| Release branch ownership | Core maintainers (same as main) | Dedicated release branch maintainers |
+| CVE backport scope | All "willing" branches | Active branches with opted-in maintainers |
 
 ### EOL Trigger
 
-A release reaches EOL when the **third subsequent minor release reaches GA**.
-For example:
+A release branch transitions to EOL when **no dedicated maintainer opts in to
+keep it alive**. This is evaluated through an explicit opt-in process modeled
+on OpenStack's approach:
 
-| Event | Supported Releases |
-|-------|-------------------|
-| v1.7 GA | v1.7, v1.6, v1.5 |
-| v1.8 GA | v1.8, v1.7, v1.6 — **v1.5 reaches EOL** |
-| v1.9 GA | v1.9, v1.8, v1.7 — **v1.6 reaches EOL** |
+1. An **EOL proposal PR** is opened against `kubevirt/sig-release` (or
+   `kubevirt/enhancements`) proposing the branch for EOL.
+2. The PR remains open for a **minimum of one month** to give maintainers,
+   downstream vendors, and other interested parties time to respond.
+3. A release branch maintainer or SIG liaison may **object** (by commenting or
+   requesting changes) to keep the branch alive. Objecting requires a
+   commitment to continue maintaining the branch — including CI health and
+   backport review.
+4. If no one objects within the window, the branch transitions to EOL.
+
+This opt-in model ensures that branches are never archived while someone is
+actively willing to maintain them, while also providing a natural pressure
+valve against unbounded branch accumulation — branches without maintainers
+are automatically retired.
 
 ### EOL Actions
 
-When a release reaches EOL, the following actions are taken:
+When a release branch transitions to EOL:
 
 1. **Branch protection**: The release branch is marked read-only. No further
    PRs will be merged.
@@ -217,15 +290,14 @@ When a release reaches EOL, the following actions are taken:
    [sig-release support matrix](https://github.com/kubevirt/sig-release/blob/main/releases/k8s-support-matrix.md).
 4. **Backport rejection**: Cherry-pick PRs targeting EOL branches are
    auto-closed by a bot with a standard message directing users to upgrade.
-5. **Announcement**: EOL is announced on the `kubevirt-dev` mailing list as
-   part of the new release announcement.
+5. **Announcement**: EOL is announced on the `kubevirt-dev` mailing list.
 
 ### CVE Handling for EOL Releases
 
 CVE reports against EOL releases will be handled as follows:
 
-- If the CVE affects a supported release, it will be fixed in supported
-  releases only.
+- If the CVE affects an active release, it will be fixed in active releases
+  only.
 - The CVE advisory will note which releases contain the fix and recommend
   upgrading from EOL releases.
 - No backports to EOL branches will be made, regardless of severity.
@@ -233,12 +305,41 @@ CVE reports against EOL releases will be handled as follows:
 This is consistent with how Kubernetes and most major open-source projects
 handle CVEs in EOL releases.
 
-### Downstream Extended Support
+### Release Branch Governance
 
-Downstream distributors who need longer support windows are free to maintain
-their own forks and backport patches independently. The upstream project's EOL
-does not prevent downstream organizations from continuing to ship patches for
-older releases in their own products.
+This VEP introduces a governance model for release branches that separates
+backport review from core `main` branch development. The model is based on
+[OpenStack's stable branch policy](https://docs.openstack.org/project-team-guide/stable-branches.html),
+where stable branch maintenance is explicitly separated from feature
+development from the moment a branch is cut.
+
+All release branches are owned by dedicated maintainer groups from the moment
+they are cut. Core `main` branch maintainers focus on feature development and
+review changes on `main`; the release branch maintainer groups review backports
+on every release branch. This addresses the full scope of the reviewer burden
+— the most recent release branches are typically the busiest for backports, so
+offloading only old branches would leave the core of the problem untouched.
+
+Release branch maintainer group membership does not require being a core
+`main` branch approver — it is a separate group managed independently.
+However, the release branch maintainer groups operate under the oversight of
+the project's core approvers and formal maintainers, who are responsible for
+defining the backporting policy, mentoring release branch maintainers, and
+providing technical guidance on complex or uncertain backports. This ensures
+that release branch quality remains aligned with the project's standards even
+though the day-to-day review work is handled by a different group.
+
+This structure also provides a natural onboarding path for new contributors:
+reviewing backports (lower-risk changes with clear correctness criteria) under
+the mentorship of core maintainers builds codebase familiarity and review
+experience, making release branch maintainers strong candidates for future
+SIG approver status on `main`.
+
+When a release branch is cut, the OWNERS and OWNERS_ALIASES files on that
+branch are updated as part of the release procedure to grant the dedicated
+maintainer group `/approve` and `/lgtm` rights. The exact team structure and
+review requirements are implementation details to be determined during the
+graduation process.
 
 ### Transition Plan
 
@@ -249,26 +350,37 @@ To avoid disruption, the following transition plan is proposed:
    this VEP is accepted.
 2. **Grace period**: Provide one full release cycle of notice. For example, if
    announced with v1.9 GA, the policy takes effect at v1.10 GA.
-3. **Initial EOL batch**: At the policy effective date, all releases older than
-   N-2 (where N is the current release) are marked EOL simultaneously. As of
-   v1.10 GA, this would mean v1.7 and earlier are EOL.
-4. **Archive old branches**: For branches that have been de facto dead for
+3. **Establish release branch maintainer groups**: During the grace period,
+   populate OWNERS_ALIASES with initial release branch maintainer groups and
+   onboard members.
+4. **Archive dead branches**: For branches that have been de facto dead for
    years (release-0.4 through release-0.57), immediately:
    - Remove any remaining CI configuration
    - Apply branch protection rules to prevent merges
    - No need to delete branches; they serve as historical record
+5. **Opt-in review for remaining old branches**: Open EOL proposal PRs for
+   all branches that lack active maintainers. Any branch where no maintainer
+   opts in within the one-month window transitions to EOL.
+6. **First governed branch cut**: The first release branch cut after policy
+   adoption uses the new OWNERS model, with the dedicated maintainer group
+   receiving `/approve` and `/lgtm` rights from the point of cut.
 
 ### Documentation Updates
 
 The following documentation changes are required:
 
-- **`docs/release.md`**: Replace the soft EOL language with the hard policy
-  defined in this VEP. Remove the sentence *"The EOL of a KubeVirt release is
-  currently not enforced."*
+- **`docs/release.md`**: Replace the soft EOL language with the maintainer-
+  driven EOL policy defined in this VEP. Remove the sentence *"The EOL of a
+  KubeVirt release is currently not enforced."* Add documentation on release
+  branch maintainer groups, the OWNERS transition at branch cut, and the
+  opt-in EOL process.
 - **`docs/release-branch-backporting.md`**: Add a section clarifying that
-  backports are only accepted for releases within the support window.
+  backports are only accepted for releases with active maintainers. Document
+  the review requirements for release branch maintainers.
 - **sig-release support matrix**: Ensure EOL releases are clearly marked and
-  the support window policy is documented.
+  the support policy is documented.
+- **OWNERS_ALIASES**: Add `release-branch-maintainers` alias with membership
+  lists.
 
 ## API Examples
 
@@ -276,88 +388,80 @@ N/A — this VEP is a process and policy change, not an API change.
 
 ## Alternatives
 
-### Alternative 1: Support 4 most recent releases
+### Alternative 1: Hard N-release EOL cutoff (e.g., 3 or 4 releases)
 
-Supporting 4 releases instead of 3 would provide a longer ~16-20 month window.
-This was considered but rejected because:
+A fixed release-count-based EOL (e.g., "only the 3 most recent releases are
+supported") was considered. This was rejected because:
 
-- It still represents a significant improvement over the current unbounded
-  state
-- It would maintain 4 active branches instead of 3, increasing maintenance
-  burden by 33%
-- The 3-release model directly mirrors Kubernetes and is well-understood by the
-  community
-- Downstream distributors who need longer windows can maintain their own
-  support independently
+- It imposes an arbitrary cutoff that does not account for whether someone is
+  willing and able to maintain the branch
+- It forces downstream distributors with longer support windows into private
+  forks even when the upstream branch is still viable
+- The maintainer-driven opt-in model achieves the same goal of bounding branch
+  count — branches without maintainers reach EOL naturally — without the
+  rigidity of a fixed number
 
 ### Alternative 2: Time-based EOL (e.g., 12 months from GA)
 
-A fixed calendar-based EOL (e.g., 12 months from GA) was considered. This was
-rejected because:
+A fixed calendar-based EOL was considered. This was rejected for similar
+reasons to the N-release cutoff:
 
-- It decouples from the Kubernetes lifecycle, which is the stated basis for
-  KubeVirt's support model
-- Release schedule variability (holidays, delays) could create confusing EOL
-  dates
-- The 3-release model is simpler to understand and communicate
+- It decouples from whether anyone is actually maintaining the branch
+- Release schedule variability could create confusing EOL dates
+- The opt-in model is more flexible while still providing a natural pressure
+  valve against unbounded branch accumulation
 
 ### Alternative 3: Maintain the status quo with better tooling
 
 Improving automation to reduce the per-branch cost of backports was considered
-as an alternative to reducing the number of branches. This was rejected
-because:
+as an alternative to changing governance. This was rejected because:
 
 - Automation cannot eliminate the review burden — humans must still review each
   cherry-pick for correctness
 - CI cost scales linearly with branch count regardless of automation
 - Old branches accumulate infrastructure incompatibilities that no amount of
   tooling can prevent
-- The fundamental problem is policy, not tooling
+- The fundamental problem is governance, not tooling
 
-### Alternative 4: Two-tier support with downstream-aligned extended maintenance
+### Alternative 4: EOL policy without dedicated maintainer groups
 
-Downstream products built on KubeVirt may have maintenance support windows
-(~18 months or more) that exceed the proposed 3-release upstream window (~12-15
-months). The gap between upstream EOL and downstream end-of-maintenance is
-typically 3-6 months, during which the downstream team must independently carry
-CVE fixes and backports without an upstream branch to target.
+An EOL-only policy (with or without a fixed release cutoff) while retaining
+the current model where core `main` branch maintainers review all release
+branch backports. This was rejected because:
 
-A two-tier model could address this:
+- It does not address reviewer fatigue — the same small group still reviews
+  all backports on all active branches
+- The most recent release branches are the busiest for backports, so archiving
+  old branches alone does not meaningfully reduce the core maintainer burden
+- It leaves the question of review responsibility for release branches
+  ambiguous, which was a recurring concern in downstream discussions
 
-- **Tier 1 — Full support (3 most recent releases)**: The upstream community
-  actively backports CVEs, bug fixes, and dependency updates. Full CI is
-  maintained. This is the upstream community commitment and matches the
-  Kubernetes model.
-- **Tier 2 — Extended maintenance (next 2 releases)**: The branch remains open
-  for merges but does not receive proactive upstream backports. Downstream
-  teams or other interested parties may propose cherry-picks, and CI for these
-  branches is maintained by the parties who need them (e.g., via sponsored CI
-  lanes in `kubevirt/project-infra`). The upstream community is not obligated
-  to initiate or review backports for Tier 2 branches.
+### Alternative 5: Open-ended best-effort branches
 
-This gives downstream distributors a place to land backports upstream rather
-than carrying them in a private fork, while keeping the upstream community's
-commitment bounded to 3 releases.
+Under this model, older branches would remain open for merges on a best-effort,
+no-obligation basis. This was rejected because:
 
-This alternative was not adopted as the primary proposal because:
+- It is functionally close to the current situation
+- Without CI, review obligations, or structured process, "open for merges"
+  provides little practical value — cherry-picks with no CI cannot be
+  validated, and merges without review risk regressions
+- It creates a false sense of support
+- Review responsibility is ambiguous
 
-- It increases the maximum number of active branches from 3 to 5, adding
-  complexity even if the obligation for the extra branches is shifted
-  downstream
-- It introduces ambiguity about review responsibilities — who approves
-  cherry-picks to Tier 2 branches if the upstream community is not obligated?
-- CI cost for Tier 2 branches must be explicitly funded and maintained by
-  downstream consumers, which requires coordination outside the upstream
-  project
-- The 3-release model is simpler to adopt as a first step; a Tier 2 extension
-  could be added later if downstream demand justifies it
+### Alternative 6: Vendor-maintained public forks (midstream model)
 
-However, if the community determines that the downstream maintenance gap is
-too large, this two-tier model is the recommended compromise over simply
-extending full support to 5 releases, as it preserves the bounded upstream
-commitment while providing a structured path for downstream needs.
+An OpenShift-style approach where vendors maintain public forks (e.g.,
+`openshift/kubevirt`) for extended branches was considered. This avoids
+governance changes in the upstream repo but was not adopted because:
 
-### Alternative 5: LTS releases
+- It requires standing up parallel CI infrastructure in the fork
+- It introduces duplication between upstream and fork for branches that are
+  still active in both places
+- Downstream tooling friction was a significant concern raised in discussions
+- The dedicated maintainer group model achieves the same separation of
+  responsibility while keeping everything upstream
+
+### Alternative 7: LTS releases
 
 Designating certain releases as Long-Term Support (LTS) with an extended
 window (e.g., 2 years) was considered. This was deferred as a potential future
@@ -372,10 +476,13 @@ VEP because:
 
 ## Scalability
 
-This VEP improves scalability by bounding the number of active release
-branches. The maintenance and CI cost of release branches scales linearly with
-the number of branches, so reducing from 8-13+ active branches to 3 represents
-a proportional reduction in resource consumption.
+This VEP improves scalability by distributing the maintenance workload across
+dedicated teams and introducing a natural mechanism to retire branches that
+lack active maintainers. Separating release branch review from core `main`
+branch development allows the two activities to scale independently. The
+opt-in EOL model provides a pressure valve: branches without maintainers are
+retired automatically, preventing unbounded branch accumulation without
+imposing an arbitrary cap.
 
 ## Update/Rollback Compatibility
 
@@ -397,6 +504,8 @@ enforcement mechanisms should be validated as follows:
   standard auto-close message
 - **Support matrix**: Verify that the sig-release matrix accurately reflects
   EOL status after each new GA release
+- **OWNERS**: Verify that release branch OWNERS files correctly reference the
+  dedicated maintainer group aliases after branch cut
 
 ## Implementation History
 
@@ -409,9 +518,11 @@ To be filled in as the VEP progresses.
 This is a process VEP and does not follow the standard Alpha/Beta/GA feature
 graduation model. Instead, the following milestones apply:
 
-### Phase 1: Policy Adoption
+### Phase 1: Policy Adoption and Governance Setup
 
 - [ ] VEP accepted by SIG Release and community vote
+- [ ] Release branch maintainer groups established and populated
+- [ ] `release-branch-maintainers` alias added to OWNERS_ALIASES
 - [ ] Documentation updated in `kubevirt/kubevirt` (`docs/release.md`,
       `docs/release-branch-backporting.md`)
 - [ ] Policy announced on `kubevirt-dev` mailing list
@@ -419,13 +530,17 @@ graduation model. Instead, the following milestones apply:
 
 ### Phase 2: Enforcement
 
-- [ ] Branch protection applied to all pre-existing EOL branches
+- [ ] Dead branches (release-0.4 through release-0.57) archived
+- [ ] EOL proposal PRs opened for remaining old branches without maintainers
+- [ ] Branch protection applied to all branches that complete EOL
 - [ ] CI lanes removed for EOL branches in `kubevirt/project-infra`
 - [ ] Auto-close bot configured for cherry-pick PRs targeting EOL branches
 - [ ] sig-release support matrix updated
+- [ ] First release branch cut under the new OWNERS model completed
 
 ### Phase 3: Steady State
 
-- [ ] EOL enforcement automated as part of the release procedure
-- [ ] Each new GA release automatically triggers EOL actions for the N-3
-      release
+- [ ] EOL opt-in review process operational for each release cycle
+- [ ] OWNERS transition at branch cut automated as part of the release
+      procedure
+- [ ] Release branch maintainer onboarding process documented and operational

--- a/veps/sig-release/233-release-branch-eol-policy/vep.md
+++ b/veps/sig-release/233-release-branch-eol-policy/vep.md
@@ -32,9 +32,28 @@ to a situation where CVE fixes, dependency updates, and other backports must be
 applied to an ever-growing number of branches, consuming significant
 contributor time and CI resources.
 
-This VEP proposes adopting a hard EOL policy modeled on the
-[Kubernetes patch release support period](https://kubernetes.io/releases/patch-releases/#support-period),
-limiting active maintenance to the **3 most recent minor releases**.
+Additionally, the same core maintainers who develop features on `main` are
+responsible for reviewing backports across all release branches. This creates
+reviewer fatigue and concentrates the maintenance burden on a small group of
+individuals — a problem that grows with each new release regardless of how many
+old branches are archived.
+
+In practice, KubeVirt has always allowed ad-hoc backports to older branches at
+the discretion of willing maintainers — the documentation even explicitly
+acknowledges that EOL "is currently not enforced". This VEP does not expand
+that practice; it formalizes it by separating the two levels of support
+explicitly: the standard 3-release support window (aligned with the Kubernetes
+support matrix) and a structured opt-in model for extended branches beyond that
+window.
+
+This VEP proposes a **dedicated release branch governance model** where all
+release branches, from the point they are cut, are owned by maintainer groups
+separate from the core `main` branch maintainers. Release branches remain
+active as long as their dedicated maintainers opt in to keep them alive, and
+transition to EOL when no maintainer is willing to continue. This is modeled
+on [OpenStack's stable branch policy](https://docs.openstack.org/project-team-guide/stable-branches.html),
+which has operated at this scale (15+ project teams, dozens of repos) for over
+a decade.
 
 ## Motivation
 
@@ -45,10 +64,12 @@ only formally tracks v1.2 through v1.7 (with v1.2-v1.4 already marked EOL),
 in practice backports continue to land on branches well beyond the documented
 support window.
 
+### CVE Backport Burden
+
 Recent CVE responses illustrate how the lack of an enforced EOL compounds
 the maintenance burden:
 
-### CVE-2023-39325 / CVE-2023-44487 — HTTP/2 Rapid Reset (Oct 2023, High)
+#### CVE-2023-39325 / CVE-2023-44487 — HTTP/2 Rapid Reset (Oct 2023, High)
 
 This high-severity vulnerability in `golang.org/x/net` and
 `google.golang.org/grpc` required backports to **7 branches**: `release-0.49`,
@@ -61,11 +82,14 @@ and `release-1.2`
 [#10675](https://github.com/kubevirt/kubevirt/pull/10675),
 [#10674](https://github.com/kubevirt/kubevirt/pull/10674),
 [#10673](https://github.com/kubevirt/kubevirt/pull/10673)).
-Under a 3-release policy, only 3 branches (1.0, 1.1, 1.2) would have been
-in scope. Notably, `release-0.49` targeted Kubernetes 1.24, which had already
-been EOL for months when the fix landed.
+Under a maintainer-driven model, responsibility for these backports would
+have been distributed across dedicated release branch maintainers rather than
+falling on core `main` branch reviewers. Notably, `release-0.49` targeted
+Kubernetes 1.24, which had already been EOL for months when the fix landed —
+a branch that would likely have reached EOL earlier if maintainer opt-in were
+required to keep it alive.
 
-### CVE-2024-21626 — runc Container Escape (Jan 2024, Critical)
+#### CVE-2024-21626 — runc Container Escape (Jan 2024, Critical)
 
 This critical container escape vulnerability required backports to
 **4 branches**: `release-0.58`, `release-0.59`, `release-1.0`, and
@@ -77,7 +101,7 @@ This critical container escape vulnerability required backports to
 `release-0.58` targeted Kubernetes 1.26, which was well past its own EOL when
 the fix was merged.
 
-### CVE-2025-22869 — golang.org/x/crypto SSH Handshake Panic (2025, High)
+#### CVE-2025-22869 — golang.org/x/crypto SSH Handshake Panic (2025, High)
 
 A panic-triggering vulnerability in the Go SSH handshake was backported to
 `release-1.3` and `release-1.4`
@@ -85,25 +109,53 @@ A panic-triggering vulnerability in the Go SSH handshake was backported to
 [#14629](https://github.com/kubevirt/kubevirt/pull/14629)),
 both of which are already marked EOL in the sig-release support matrix.
 
-### CVE-2025-47913 — golang.org/x/crypto Denial of Service (2025, High)
+#### CVE-2025-47913 — golang.org/x/crypto Denial of Service (2025, High)
 
 A denial-of-service vulnerability in Go's crypto library was backported to
 `release-1.5` and `release-1.6`
 ([#16887](https://github.com/kubevirt/kubevirt/pull/16887),
 [#16870](https://github.com/kubevirt/kubevirt/pull/16870)).
 
-### CVE Backport Scope Comparison
+#### CVE Backport Summary
 
-| CVE | Date | Severity | Branches Backported | Under 3-Release Policy |
-|-----|------|----------|--------------------:|---------------------:|
-| CVE-2023-39325 | Oct 2023 | High | 7 | 3 |
-| CVE-2024-21626 | Jan 2024 | Critical | 4 | 3 |
-| CVE-2025-22869 | 2025 | High | 2 | 2 |
-| CVE-2025-47913 | 2025 | High | 2 | 2 |
+| CVE | Date | Severity | Branches Backported |
+|-----|------|----------|--------------------:|
+| CVE-2023-39325 | Oct 2023 | High | 7 |
+| CVE-2024-21626 | Jan 2024 | Critical | 4 |
+| CVE-2025-22869 | 2025 | High | 2 |
+| CVE-2025-47913 | 2025 | High | 2 |
 
-The pattern is clear: without an enforced EOL, each CVE response requires
-work across an unpredictable and growing set of branches. This creates
-several compounding problems:
+Under this VEP's governance model, the review and CI burden for these
+backports would be carried by dedicated release branch maintainers rather
+than core `main` branch reviewers. Branches without active maintainers
+would have already transitioned to EOL, naturally reducing the scope.
+
+### Reviewer Burden
+
+The unbounded branch count is only part of the problem. The same core
+maintainers who review feature work on `main` also review every backport
+cherry-pick across all release branches. This creates compounding reviewer
+fatigue:
+
+- Approximately **half of all upstream PRs are backports** — from various
+  contributors and downstream vendors — creating significant reviewer and CI
+  load
+- Individual core maintainers report spending **up to half of their review
+  time** on backports rather than feature development
+- Backports are often a source of long-running fixes where old branches are
+  discovered to be non-functional
+- Fixes for customer problems are sometimes raised upstream but never
+  backported, with missing bug tracking and no follow-up
+- Backports are sometimes raised for CVEs that don't actually affect upstream
+- Edge cases with forked dependencies (e.g.
+  [kubevirt#17692](https://github.com/kubevirt/kubevirt/pull/17692)) require
+  time-consuming manual verification by maintainers
+
+### Summary
+
+The pattern is clear: without separating release branch maintenance from core
+development and without a mechanism to EOL branches that lack active
+maintainers, the project faces:
 
 1. **Unsustainable contributor burden**: Each CVE or critical fix must be
    backported, reviewed, and merged across many branches. The HTTP/2 rapid
@@ -112,27 +164,35 @@ several compounding problems:
 2. **Unbounded CI cost**: CI lanes must be maintained and executed for every
    active release branch. Old branches frequently break due to infrastructure
    drift, consuming debugging time unrelated to the fix itself.
-3. **False sense of security**: Users on ancient releases receive sporadic CVE
+3. **Reviewer fatigue**: Core maintainers context-switch between feature
+   reviews on `main` and backport reviews across release branches, with
+   backports consuming up to half their review bandwidth.
+4. **False sense of security**: Users on ancient releases receive sporadic CVE
    fixes but no guarantee of comprehensive coverage, creating a false sense
    that the release is fully maintained.
-4. **No upgrade incentive**: Without a hard EOL, downstream consumers have no
-   forcing function to upgrade to supported releases.
-5. **Inconsistency with stated policy**: The documentation already ties EOL to
+5. **Improved upgrade incentive**: Without any EOL mechanism, downstream
+   consumers have no forcing function to upgrade to supported releases. While
+   the maintainer-driven model does not impose a hard deadline, branches will
+   eventually reach EOL when maintainers step down — providing a clearer signal
+   than the current indefinite "not enforced" state.
+6. **Inconsistency with stated policy**: The documentation already ties EOL to
    Kubernetes support periods, but the lack of enforcement makes the policy
    meaningless in practice. Fixes are landing on branches targeting Kubernetes
    versions that Kubernetes itself stopped supporting long ago.
 
 ## Goals
 
-- Define a hard EOL policy for KubeVirt release branches with a fixed support
-  window
-- Align the KubeVirt release lifecycle with the Kubernetes release support
-  model
-- Reduce the number of actively maintained release branches to a bounded,
-  predictable set
-- Establish automated enforcement of EOL through CI and branch protection
-- Provide a clear transition plan for the existing backlog of unmaintained
-  branches
+- Preserve the standard 3-release support window (aligned with the Kubernetes
+  support matrix) as the primary support commitment
+- Formalize extended support beyond the 3-release window as explicitly limited
+  to security and critical fixes, dependent on dedicated maintainer availability
+- Reduce backport and CVE review burden on core maintainers
+- Ensure release branches have a clear, enforced EOL mechanism so unmaintained
+  branches are retired rather than accumulating indefinitely
+- Make EOL status unambiguous and machine-enforced, eliminating the current
+  soft/unenforced policy
+- Resolve the current backlog of de-facto dead branches with no active
+  maintainers
 
 ## Non Goals
 
@@ -148,30 +208,41 @@ several compounding problems:
 
 - **KubeVirt release maintainers**: Contributors who cut releases, manage CI
   lanes, and process backport PRs
+- **Release branch maintainers**: Dedicated reviewers/approvers responsible for
+  backport review and CI health on release branches, separate from core `main`
+  branch maintainers
 - **KubeVirt contributors**: Developers who must create and shepherd cherry-pick
   PRs for bug fixes and CVEs
-- **Downstream distributors**: Organizations (e.g., Red Hat, SUSE) that
-  consume KubeVirt releases and may maintain their own extended support windows
-  independently
+- **Downstream distributors**: Organizations that consume KubeVirt releases
+  and may maintain their own extended support windows independently
 - **End users**: Operators running KubeVirt clusters who need to understand
   which versions receive security and bug fixes
 
 ## User Stories
 
-- As a **release maintainer**, I want a bounded number of release branches to
-  maintain so that CVE response does not require cherry-picks to 10+ branches.
+- As a **release maintainer**, I want release branches to have dedicated
+  maintainers and a clear EOL process so that unmaintained branches are
+  retired and do not accumulate indefinitely.
+- As a **core maintainer**, I want release branch review to be handled by a
+  dedicated group so that I can focus my review time on feature development on
+  `main`.
+- As a **release branch maintainer**, I want clear ownership of specific
+  release branches so that I know what I am responsible for and can build
+  expertise in the backporting process.
 - As a **contributor**, I want a clear policy on which branches accept
-  backports so that I do not waste time preparing cherry-picks for unsupported
+  backports so that I do not waste time preparing cherry-picks for EOL
   releases.
-- As a **downstream distributor**, I want a predictable upstream EOL schedule
-  so that I can plan my own support lifecycle accordingly.
-- As an **end user**, I want to know exactly which KubeVirt versions are
-  supported so that I can plan upgrades within the support window.
+- As a **downstream distributor**, I want release branches to remain active
+  upstream as long as I am willing to provide maintainers, so that I do not
+  need to maintain private forks unnecessarily.
+- As an **end user**, I want to know exactly which KubeVirt versions have
+  active maintainers so that I can plan upgrades accordingly.
 
 ## Repos
 
 - [kubevirt/kubevirt](https://github.com/kubevirt/kubevirt) — release branch
-  management, branch protection, documentation updates
+  management, branch protection, OWNERS/OWNERS_ALIASES updates, documentation
+  updates
 - [kubevirt/sig-release](https://github.com/kubevirt/sig-release) — support
   matrix updates, release schedule documentation
 - [kubevirt/project-infra](https://github.com/kubevirt/project-infra) — CI
@@ -179,35 +250,57 @@ several compounding problems:
 
 ## Design
 
-### Support Window
+### Branch Lifecycle
 
-KubeVirt will support the **3 most recent minor releases**. With 3 minor
-releases per year (~every 15 weeks), this provides a support window of
-approximately **12-15 months** per release — closely matching the Kubernetes
-support period of ~14 months.
+A release branch progresses through three phases:
+
+| Phase | Ownership | CI | Upstream Obligation |
+|-------|-----------|-----|---------------------|
+| **Active** | Dedicated release branch maintainers | Full Prow presubmit + periodic | Maintainers actively review backports and monitor CI |
+| **Maintainer opt-in review** | Same, subject to re-confirmation | Maintained by opt-in party | Branch stays alive only if a maintainer explicitly opts in |
+| **End of Life** | None | Removed | Branch archived, no further merges |
 
 | Aspect | Current Policy | Proposed Policy |
 |--------|---------------|-----------------|
-| Supported releases | Unbounded ("not enforced") | 3 most recent minor releases |
-| Max active branches | 8-13+ for CVEs | 3 (plus main) |
-| EOL enforcement | Soft/optional | Hard cutoff |
-| CVE backport scope | All "willing" branches | 3 releases |
-| Support window | Indefinite | ~12-15 months |
+| Supported releases | Unbounded ("not enforced") | Maintainer-driven: active as long as someone opts in |
+| EOL enforcement | Soft/optional | Hard: absence of maintainers = automatic EOL |
+| Release branch ownership | Core maintainers (same as main) | Dedicated release branch maintainers |
+| CVE backport scope | All "willing" branches | Active branches with opted-in maintainers |
 
 ### EOL Trigger
 
-A release reaches EOL when the **third subsequent minor release reaches GA**.
-For example:
+A release branch transitions to EOL when **no dedicated maintainer opts in to
+keep it alive**. This is evaluated through an explicit opt-in process modeled
+on OpenStack's approach:
 
-| Event | Supported Releases |
-|-------|-------------------|
-| v1.7 GA | v1.7, v1.6, v1.5 |
-| v1.8 GA | v1.8, v1.7, v1.6 — **v1.5 reaches EOL** |
-| v1.9 GA | v1.9, v1.8, v1.7 — **v1.6 reaches EOL** |
+1. An **EOL proposal PR** is opened against `kubevirt/sig-release` (or
+   `kubevirt/enhancements`) proposing the branch for EOL.
+2. The PR remains open for a **minimum of one month** to give maintainers,
+   downstream vendors, and other interested parties time to respond.
+3. A release branch maintainer or SIG liaison may **object** (by commenting or
+   requesting changes) to keep the branch alive. Objecting requires a
+   commitment to continue maintaining the branch — including CI health and
+   backport review.
+4. If no one objects within the window, the branch transitions to EOL.
+
+This opt-in model ensures that branches are never archived while someone is
+actively willing to maintain them, while also providing a natural pressure
+valve against unbounded branch accumulation — branches without maintainers
+are automatically retired.
+
+**Automation**: The EOL proposal PR is not opened manually. It reuses the
+existing `project-infra` periodic that already runs over active approvers —
+`periodic-community-remove-inactive-users-from-orgs-yaml`, which runs the
+`contributions` generator (`go run ./generators/cmd/contributions --months 12`)
+to identify inactive users and opens automated PRs against `orgs.yaml` /
+`alumni.yaml`. Extending the same job to flag a release branch whose maintainer
+group has no active approvers, and to open the EOL proposal PR, keeps the
+trigger objective, consistent with how the project already tracks maintainer
+activity, and free of any new bespoke process.
 
 ### EOL Actions
 
-When a release reaches EOL, the following actions are taken:
+When a release branch transitions to EOL:
 
 1. **Branch protection**: The release branch is marked read-only. No further
    PRs will be merged.
@@ -217,15 +310,14 @@ When a release reaches EOL, the following actions are taken:
    [sig-release support matrix](https://github.com/kubevirt/sig-release/blob/main/releases/k8s-support-matrix.md).
 4. **Backport rejection**: Cherry-pick PRs targeting EOL branches are
    auto-closed by a bot with a standard message directing users to upgrade.
-5. **Announcement**: EOL is announced on the `kubevirt-dev` mailing list as
-   part of the new release announcement.
+5. **Announcement**: EOL is announced on the `kubevirt-dev` mailing list.
 
 ### CVE Handling for EOL Releases
 
 CVE reports against EOL releases will be handled as follows:
 
-- If the CVE affects a supported release, it will be fixed in supported
-  releases only.
+- If the CVE affects an active release, it will be fixed in active releases
+  only.
 - The CVE advisory will note which releases contain the fix and recommend
   upgrading from EOL releases.
 - No backports to EOL branches will be made, regardless of severity.
@@ -233,12 +325,35 @@ CVE reports against EOL releases will be handled as follows:
 This is consistent with how Kubernetes and most major open-source projects
 handle CVEs in EOL releases.
 
-### Downstream Extended Support
+### Release Branch Governance
 
-Downstream distributors who need longer support windows are free to maintain
-their own forks and backport patches independently. The upstream project's EOL
-does not prevent downstream organizations from continuing to ship patches for
-older releases in their own products.
+This VEP introduces a governance model for release branches that separates
+backport review from core `main` branch development. The model is based on
+[OpenStack's stable branch policy](https://docs.openstack.org/project-team-guide/stable-branches.html),
+where stable branch maintenance is explicitly separated from feature
+development from the moment a branch is cut.
+
+All release branches are owned by dedicated maintainer groups from the moment
+they are cut. Core `main` branch maintainers focus on feature development and
+review changes on `main`; the release branch maintainer groups review backports
+on every release branch. This addresses the full scope of the reviewer burden
+— the most recent release branches are typically the busiest for backports, so
+offloading only old branches would leave the core of the problem untouched.
+
+Release branch maintainer group membership does not require being a core
+`main` branch approver — it is a separate group managed independently.
+However, the release branch maintainer groups operate under the oversight of
+the project's core approvers and formal maintainers, who are responsible for
+defining the backporting policy, mentoring release branch maintainers, and
+providing technical guidance on complex or uncertain backports. This ensures
+that release branch quality remains aligned with the project's standards even
+though the day-to-day review work is handled by a different group.
+
+When a release branch is cut, the OWNERS and OWNERS_ALIASES files on that
+branch are updated as part of the release procedure to grant the dedicated
+maintainer group `/approve` and `/lgtm` rights. The exact team structure and
+review requirements are implementation details to be determined during the
+graduation process.
 
 ### Transition Plan
 
@@ -249,26 +364,46 @@ To avoid disruption, the following transition plan is proposed:
    this VEP is accepted.
 2. **Grace period**: Provide one full release cycle of notice. For example, if
    announced with v1.9 GA, the policy takes effect at v1.10 GA.
-3. **Initial EOL batch**: At the policy effective date, all releases older than
-   N-2 (where N is the current release) are marked EOL simultaneously. As of
-   v1.10 GA, this would mean v1.7 and earlier are EOL.
-4. **Archive old branches**: For branches that have been de facto dead for
-   years (release-0.4 through release-0.57), immediately:
-   - Remove any remaining CI configuration
-   - Apply branch protection rules to prevent merges
-   - No need to delete branches; they serve as historical record
+3. **Establish release branch maintainer groups**: During the grace period,
+   populate OWNERS_ALIASES with initial release branch maintainer groups and
+   onboard members.
+4. **Archive dead branches**: Branches de facto dead for years (release-0.4
+   through release-0.57) have already been archived in
+   [kubevirt/project-infra#5041](https://github.com/kubevirt/project-infra/pull/5041)
+   ([kubevirt/kubevirt#17717](https://github.com/kubevirt/kubevirt/issues/17717)),
+   establishing the repeatable procedure applied to every branch at EOL:
+   - Remove the per-branch presubmit CI job configuration.
+   - Set `unmanaged: true` in the Prow branch-protection config, opting the
+     branch out of the branchprotector (required because repo-level
+     `protect: true` otherwise resets manual protection on each hourly sync).
+   - Set `lock_branch: true` via the GitHub API (a follow-up, since
+     branchprotector cannot manage this field itself).
+
+   End state: no CI jobs, locked read-only, no further merges. Branches are
+   not deleted; they remain as a historical record.
+5. **Opt-in review for remaining old branches**: Open EOL proposal PRs for
+   all branches that lack active maintainers. Any branch where no maintainer
+   opts in within the one-month window transitions to EOL.
+6. **First governed branch cut**: The first release branch cut after policy
+   adoption uses the new OWNERS model, with the dedicated maintainer group
+   receiving `/approve` and `/lgtm` rights from the point of cut.
 
 ### Documentation Updates
 
 The following documentation changes are required:
 
-- **`docs/release.md`**: Replace the soft EOL language with the hard policy
-  defined in this VEP. Remove the sentence *"The EOL of a KubeVirt release is
-  currently not enforced."*
+- **`docs/release.md`**: Replace the soft EOL language with the maintainer-
+  driven EOL policy defined in this VEP. Remove the sentence *"The EOL of a
+  KubeVirt release is currently not enforced."* Add documentation on release
+  branch maintainer groups, the OWNERS transition at branch cut, and the
+  opt-in EOL process.
 - **`docs/release-branch-backporting.md`**: Add a section clarifying that
-  backports are only accepted for releases within the support window.
+  backports are only accepted for releases with active maintainers. Document
+  the review requirements for release branch maintainers.
 - **sig-release support matrix**: Ensure EOL releases are clearly marked and
-  the support window policy is documented.
+  the support policy is documented.
+- **OWNERS_ALIASES**: Add `release-branch-maintainers` alias with membership
+  lists.
 
 ## API Examples
 
@@ -276,88 +411,80 @@ N/A — this VEP is a process and policy change, not an API change.
 
 ## Alternatives
 
-### Alternative 1: Support 4 most recent releases
+### Alternative 1: Hard N-release EOL cutoff (e.g., 3 or 4 releases)
 
-Supporting 4 releases instead of 3 would provide a longer ~16-20 month window.
-This was considered but rejected because:
+A fixed release-count-based EOL (e.g., "only the 3 most recent releases are
+supported") was considered. This was rejected because:
 
-- It still represents a significant improvement over the current unbounded
-  state
-- It would maintain 4 active branches instead of 3, increasing maintenance
-  burden by 33%
-- The 3-release model directly mirrors Kubernetes and is well-understood by the
-  community
-- Downstream distributors who need longer windows can maintain their own
-  support independently
+- It imposes an arbitrary cutoff that does not account for whether someone is
+  willing and able to maintain the branch
+- It forces downstream distributors with longer support windows into private
+  forks even when the upstream branch is still viable
+- The maintainer-driven opt-in model achieves the same goal of bounding branch
+  count — branches without maintainers reach EOL naturally — without the
+  rigidity of a fixed number
 
 ### Alternative 2: Time-based EOL (e.g., 12 months from GA)
 
-A fixed calendar-based EOL (e.g., 12 months from GA) was considered. This was
-rejected because:
+A fixed calendar-based EOL was considered. This was rejected for similar
+reasons to the N-release cutoff:
 
-- It decouples from the Kubernetes lifecycle, which is the stated basis for
-  KubeVirt's support model
-- Release schedule variability (holidays, delays) could create confusing EOL
-  dates
-- The 3-release model is simpler to understand and communicate
+- It decouples from whether anyone is actually maintaining the branch
+- Release schedule variability could create confusing EOL dates
+- The opt-in model is more flexible while still providing a natural pressure
+  valve against unbounded branch accumulation
 
 ### Alternative 3: Maintain the status quo with better tooling
 
 Improving automation to reduce the per-branch cost of backports was considered
-as an alternative to reducing the number of branches. This was rejected
-because:
+as an alternative to changing governance. This was rejected because:
 
 - Automation cannot eliminate the review burden — humans must still review each
   cherry-pick for correctness
 - CI cost scales linearly with branch count regardless of automation
 - Old branches accumulate infrastructure incompatibilities that no amount of
   tooling can prevent
-- The fundamental problem is policy, not tooling
+- The fundamental problem is governance, not tooling
 
-### Alternative 4: Two-tier support with downstream-aligned extended maintenance
+### Alternative 4: EOL policy without dedicated maintainer groups
 
-Downstream products built on KubeVirt may have maintenance support windows
-(~18 months or more) that exceed the proposed 3-release upstream window (~12-15
-months). The gap between upstream EOL and downstream end-of-maintenance is
-typically 3-6 months, during which the downstream team must independently carry
-CVE fixes and backports without an upstream branch to target.
+An EOL-only policy (with or without a fixed release cutoff) while retaining
+the current model where core `main` branch maintainers review all release
+branch backports. This was rejected because:
 
-A two-tier model could address this:
+- It does not address reviewer fatigue — the same small group still reviews
+  all backports on all active branches
+- The most recent release branches are the busiest for backports, so archiving
+  old branches alone does not meaningfully reduce the core maintainer burden
+- It leaves the question of review responsibility for release branches
+  ambiguous, which was a recurring concern in downstream discussions
 
-- **Tier 1 — Full support (3 most recent releases)**: The upstream community
-  actively backports CVEs, bug fixes, and dependency updates. Full CI is
-  maintained. This is the upstream community commitment and matches the
-  Kubernetes model.
-- **Tier 2 — Extended maintenance (next 2 releases)**: The branch remains open
-  for merges but does not receive proactive upstream backports. Downstream
-  teams or other interested parties may propose cherry-picks, and CI for these
-  branches is maintained by the parties who need them (e.g., via sponsored CI
-  lanes in `kubevirt/project-infra`). The upstream community is not obligated
-  to initiate or review backports for Tier 2 branches.
+### Alternative 5: Open-ended best-effort branches
 
-This gives downstream distributors a place to land backports upstream rather
-than carrying them in a private fork, while keeping the upstream community's
-commitment bounded to 3 releases.
+Under this model, older branches would remain open for merges on a best-effort,
+no-obligation basis. This was rejected because:
 
-This alternative was not adopted as the primary proposal because:
+- It is functionally close to the current situation
+- Without CI, review obligations, or structured process, "open for merges"
+  provides little practical value — cherry-picks with no CI cannot be
+  validated, and merges without review risk regressions
+- It creates a false sense of support
+- Review responsibility is ambiguous
 
-- It increases the maximum number of active branches from 3 to 5, adding
-  complexity even if the obligation for the extra branches is shifted
-  downstream
-- It introduces ambiguity about review responsibilities — who approves
-  cherry-picks to Tier 2 branches if the upstream community is not obligated?
-- CI cost for Tier 2 branches must be explicitly funded and maintained by
-  downstream consumers, which requires coordination outside the upstream
-  project
-- The 3-release model is simpler to adopt as a first step; a Tier 2 extension
-  could be added later if downstream demand justifies it
+### Alternative 6: Vendor-maintained public forks (midstream model)
 
-However, if the community determines that the downstream maintenance gap is
-too large, this two-tier model is the recommended compromise over simply
-extending full support to 5 releases, as it preserves the bounded upstream
-commitment while providing a structured path for downstream needs.
+An OpenShift-style approach where vendors maintain public forks (e.g.,
+`openshift/kubevirt`) for extended branches was considered. This avoids
+governance changes in the upstream repo but was not adopted because:
 
-### Alternative 5: LTS releases
+- It requires standing up parallel CI infrastructure in the fork
+- It introduces duplication between upstream and fork for branches that are
+  still active in both places
+- Downstream tooling friction was a significant concern raised in discussions
+- The dedicated maintainer group model achieves the same separation of
+  responsibility while keeping everything upstream
+
+### Alternative 7: LTS releases
 
 Designating certain releases as Long-Term Support (LTS) with an extended
 window (e.g., 2 years) was considered. This was deferred as a potential future
@@ -372,10 +499,13 @@ VEP because:
 
 ## Scalability
 
-This VEP improves scalability by bounding the number of active release
-branches. The maintenance and CI cost of release branches scales linearly with
-the number of branches, so reducing from 8-13+ active branches to 3 represents
-a proportional reduction in resource consumption.
+This VEP improves scalability by distributing the maintenance workload across
+dedicated teams and introducing a natural mechanism to retire branches that
+lack active maintainers. Separating release branch review from core `main`
+branch development allows the two activities to scale independently. The
+opt-in EOL model provides a pressure valve: branches without maintainers are
+retired automatically, preventing unbounded branch accumulation without
+imposing an arbitrary cap.
 
 ## Update/Rollback Compatibility
 
@@ -397,6 +527,8 @@ enforcement mechanisms should be validated as follows:
   standard auto-close message
 - **Support matrix**: Verify that the sig-release matrix accurately reflects
   EOL status after each new GA release
+- **OWNERS**: Verify that release branch OWNERS files correctly reference the
+  dedicated maintainer group aliases after branch cut
 
 ## Implementation History
 
@@ -409,9 +541,11 @@ To be filled in as the VEP progresses.
 This is a process VEP and does not follow the standard Alpha/Beta/GA feature
 graduation model. Instead, the following milestones apply:
 
-### Phase 1: Policy Adoption
+### Phase 1: Policy Adoption and Governance Setup
 
 - [ ] VEP accepted by SIG Release and community vote
+- [ ] Release branch maintainer groups established and populated
+- [ ] `release-branch-maintainers` alias added to OWNERS_ALIASES
 - [ ] Documentation updated in `kubevirt/kubevirt` (`docs/release.md`,
       `docs/release-branch-backporting.md`)
 - [ ] Policy announced on `kubevirt-dev` mailing list
@@ -419,13 +553,17 @@ graduation model. Instead, the following milestones apply:
 
 ### Phase 2: Enforcement
 
-- [ ] Branch protection applied to all pre-existing EOL branches
+- [ ] Dead branches (release-0.4 through release-0.57) archived
+- [ ] EOL proposal PRs opened for remaining old branches without maintainers
+- [ ] Branch protection applied to all branches that complete EOL
 - [ ] CI lanes removed for EOL branches in `kubevirt/project-infra`
 - [ ] Auto-close bot configured for cherry-pick PRs targeting EOL branches
 - [ ] sig-release support matrix updated
+- [ ] First release branch cut under the new OWNERS model completed
 
 ### Phase 3: Steady State
 
-- [ ] EOL enforcement automated as part of the release procedure
-- [ ] Each new GA release automatically triggers EOL actions for the N-3
-      release
+- [ ] EOL opt-in review process operational for each release cycle
+- [ ] OWNERS transition at branch cut automated as part of the release
+      procedure
+- [ ] Release branch maintainer onboarding process documented and operational


### PR DESCRIPTION
### VEP Metadata

**Tracking issue**: https://github.com/kubevirt/enhancements/issues/233
**SIG label**: /sig release

### What this PR does

Reworks VEP #233 to replace the hard 3-release EOL cutoff with a dedicated release branch maintainer governance model.

Key changes from the original VEP:

- **Two explicit support levels**: The standard 3-release support window (aligned with the Kubernetes support matrix) is preserved as the primary support commitment. Beyond that, extended support is formalized as explicitly limited to security and critical fixes, dependent on dedicated maintainer availability.
- **Dedicated maintainer groups**: All release branches are owned by dedicated maintainer groups from the point they are cut, not by core `main` branch maintainers. This directly addresses the reviewer fatigue where core maintainers spend up to half their review time on backports.
- **Core maintainer oversight**: Release branch maintainer groups operate under the oversight of the project's core approvers, who define backporting policy, mentor release branch maintainers, and provide technical guidance on complex backports.
- **Maintainer-driven EOL**: Instead of a hard N-release cutoff, branches transition to EOL when no dedicated maintainer opts in to keep them alive. An EOL proposal PR is opened and must remain open for one month — anyone can object by committing to continue maintenance. This is modeled on [OpenStack's stable branch policy](https://docs.openstack.org/project-team-guide/stable-branches.html).
- **OWNERS transition at branch cut**: Automated as part of the release procedure using OWNERS_ALIASES.

This PR supersedes [PR #334](https://github.com/kubevirt/enhancements/pull/334) (two-tier model), [PR #335](https://github.com/kubevirt/enhancements/pull/335) (best-effort branches), and addresses the governance gap that motivated [PR #317](https://github.com/kubevirt/enhancements/pull/317) (midstream fork).

### Special notes for your reviewer

This is a substantial rework of the VEP. The branch lifecycle and EOL mechanics sections have been replaced entirely. The CVE motivation examples are preserved. The alternatives section has been reorganised — the original 3-release-only model and two-tier model are now listed as considered-and-rejected alternatives.

The VEP explicitly preserves the 3-release support window as the primary commitment and scopes the extended maintainer-driven model strictly to security and critical fixes. The maintainer-driven opt-in EOL process means branches without active maintainers are retired naturally rather than via an arbitrary release count, consistent with OpenStack's stable branch model.