### PR TITLE
VEP #340: launchsecurity: Add InitData resource for TDX and SNP

### DIFF
--- a/veps/sig-compute/340-launchsecurity-inject-initdata/injectinitdata-proposal.md
+++ b/veps/sig-compute/340-launchsecurity-inject-initdata/injectinitdata-proposal.md
@@ -1,0 +1,364 @@
+# VEP #340: launchsecurity: add injectInitdata subresource for TDX and SNP
+
+## VEP Status Metadata
+
+### Target releases
+
+This VEP does not have graduation phases guarded by a feature gate.
+- Ship target version:
+
+
+### Release Signoff Checklist
+
+Items marked with (R) are required *prior to targeting to a milestone / release*.
+
+- [ ] (R) Enhancement issue created, which links to VEP dir in [kubevirt/enhancements] (not the initial VEP PR)
+
+## Overview
+
+Confidential VMs (CVMs) require per-VM configuration values to be injected
+before boot so the guest can use them during remote attestation. These values
+are incorporated into hardware measurement registers and become part of the
+attestation report, allowing the guest to prove that the host provided the
+expected configuration.
+
+This proposal adds two new KubeVirt subresource endpoints that allow an
+external operator to inject these values into a VMI while it is in the
+`Scheduled` phase, before QEMU starts:
+
+- `PUT virtualmachineinstances/{name}/tdx/injectInitdata` — for Intel TDX
+- `PUT virtualmachineinstances/{name}/snp/injectInitdata` — for AMD SEV-SNP
+
+The design follows the existing SEV attestation pattern where `virt-handler`
+blocks VM startup until the required attestation data is provided via a
+subresource, and the VM is explicitly unpaused by the external operator
+after injection.
+
+In this VEP, Initdata wording refers to
+[initData](https://github.com/confidential-containers/trustee/blob/main/kbs/docs/initdata.md).
+The Initdata Specification defines the key data structure and algorithms to
+inject any well-defined data from untrusted host into TEE.
+
+## Motivation
+
+Organizations deploying confidential VMs need the strongest possible
+attestation guarantees. A key use case is encrypted disk provisioning: an
+external operator injects a reference to a secret stored in a Key Broker
+Service (KBS) into the guest before boot. The guest then attests to the KBS
+and retrieves the secret only if the attestation passes. The injected values
+become part of the hardware measurement, ensuring the host cannot tamper with
+them undetected.
+
+Currently, KubeVirt supports this flow for SEV via the
+`sev/fetchCertChain` and `sev/setupSession` subresources. However, Intel TDX
+and AMD SEV-SNP have no equivalent mechanism. Users resort to hook sidecars
+that modify the libvirt domain XML directly, bypassing KubeVirt's API and
+losing auditability, RBAC control, and compatibility with future KubeVirt
+versions.
+
+This proposal fills the gap by extending the VMI API with the fields and
+subresources needed for TDX and SEV-SNP attestation-based secret delivery.
+
+## Goals
+
+- Expose TDX and SEV-SNP initdata fields in the VMI API so users can
+  configure attestation-relevant registers (`mrConfigId`, `hostData`,
+  `oemStrings`) declaratively or at runtime.
+- Provide a KubeVirt-native mechanism for external operators to inject
+  initdata into a VMI after scheduling and before boot.
+- Extend the existing SEV attestation pattern to TDX and SEV-SNP.
+
+## Non Goals
+
+- This proposal does not implement the external operator that calls the
+  subresource. The operator is a separate component outside of KubeVirt.
+- This proposal does not define how the guest uses the injected values after
+  boot (that is guest-side logic, e.g., `systemd-repart`, `systemd-cryptsetup`).
+
+## Definition of Users
+
+- Cluster Administrators: Deploy and manage the external operator that
+  automates the attestation provisioning flow. Configure RBAC permissions for
+  the `injectInitdata` subresource.
+
+- VM Users: secret delivery flow to work transparently once the cluster
+  administrator has configured the external operator.
+
+## User Stories
+
+- As a VM user, I want to configure initdata registers like `mrConfigId`,
+  `hostData`, and `oemStrings` in the VM definition so that they are
+  injected into the VM at boot time.
+- As a VM user, I want to tell the Kubernetes infrastructure to inject a
+  secret key into my confidential VM.
+- As a cluster administrator, I want to configure an external operator
+  that automates the attestation provisioning flow so that VM users do not
+  need to manage the injection manually.
+
+## Repos
+
+- [kubevirt/kubevirt](https://github.com/kubevirt/kubevirt)
+
+## Design
+
+The design follows the existing SEV attestation pattern in KubeVirt. The key
+components are:
+
+### API extensions
+
+New fields added to the VMI spec:
+
+```go
+// In schema.go
+type TDX struct {
+    MRConfigId  string          `json:"mrConfigId,omitempty"`
+    Attestation *TDXAttestation `json:"attestation,omitempty"`
+}
+
+type SEVSNP struct {
+    HostData    string              `json:"hostData,omitempty"`
+    Attestation *SEVSNPAttestation  `json:"attestation,omitempty"`
+}
+
+type Firmware struct {
+    // ... existing fields ...
+    OEMStrings []string `json:"oemStrings,omitempty"`
+}
+```
+
+The `Attestation` field is a marker: when present, it signals that the VMI
+requires initdata injection before boot. Without `Attestation`, the registers
+can be set directly from the YAML. `mrConfigId`/`hostData` start empty and are
+filled via the subresource. `oemStrings` carries a reference (e.g., a KBS
+resource path) that the guest reads from SMBIOS Type 11 at boot.
+
+### Subresource endpoints
+
+Two new `PUT` endpoints registered in `virt-api`:
+
+| Endpoint | Platform | Payload |
+|---|---|---|
+| `PUT .../virtualmachineinstances/{name}/tdx/injectInitdata` | Intel TDX | `{"mrConfigId": "<base64>", "oemStrings": [...]}` |
+| `PUT .../virtualmachineinstances/{name}/snp/injectInitdata` | AMD SEV-SNP | `{"hostData": "<base64>", "oemStrings": [...]}` |
+
+Both endpoints:
+1. Verify the VMI is in `Scheduled` phase.
+2. Verify the `Attestation` field is set.
+3. Verify the initdata field (`mrConfigId`/`hostData`) is not already set.
+4. Validate the base64 value decodes to the correct length (48 bytes for TDX,
+   32 bytes for SNP).
+5. Apply a JSON patch to the VMI spec.
+
+### virt-handler blocking
+
+When `TDX.Attestation` (or `SEVSNP.Attestation`) is set, `virt-handler`
+blocks VM synchronization until `mrConfigId` (or `hostData`) is populated.
+This prevents QEMU from starting before the external operator has injected
+the values. The check mirrors the existing `shouldWaitForSEVAttestation`
+function.
+
+### Libvirt XML translation
+
+The new fields are translated to libvirt domain XML in the converter layer:
+
+- `TDX.MRConfigId` -> `<launchSecurity type="tdx"><mrConfigId>...</mrConfigId></launchSecurity>`
+- `SEVSNP.HostData` -> `<launchSecurity type="sev-snp"><hostData>...</hostData></launchSecurity>`
+- `Firmware.OEMStrings` -> `<sysinfo type="smbios"><oemStrings><entry>...</entry></oemStrings></sysinfo>`
+
+### Start strategy
+
+The VMI must be created with `startStrategy: Paused`. This ensures QEMU
+boots in paused state, giving the external operator a window to:
+1. Call the provisioner to obtain the values.
+2. Inject them via `injectInitdata`.
+3. Wait for the VMI to reach `Running` phase (QEMU started but paused).
+4. Call `unpause` to resume guest execution.
+
+This is validated at admission time: if `Attestation` is set but
+`startStrategy` is not `Paused`, the VMI is rejected.
+
+### Security Considerations
+
+- The `injectInitdata` subresource is guarded by RBAC. Only components with
+  the appropriate ClusterRole can call the endpoint. This prevents unauthorized
+  injection of attestation values.
+- The injected `mrConfigId` and `hostData` are measured by the hardware (TDX
+  or SEV-SNP respectively). Any tampering is detectable by the guest during
+  remote attestation. The host infrastructure provider cannot modify these
+  values after injection without invalidating the attestation report.
+- The `oemStrings` field carries a reference (e.g., a KBS resource path), not
+  the actual secret. The secret is only released by the Key Broker Service
+  after the guest passes attestation.
+- The design does not store secrets in Kubernetes objects. The VMI spec only
+  contains measurement IDs and resource paths.
+
+## API Examples
+
+### TDX with static mrConfigId
+
+When `mrConfigId` is known at VM creation time, it can be set directly in
+the YAML. No `attestation` field, no `startStrategy: Paused`, and no
+subresource call is needed:
+
+```yaml
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+spec:
+  template:
+    spec:
+      domain:
+        launchSecurity:
+          tdx:
+            mrConfigId: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+        firmware:
+          bootloader:
+            efi:
+              secureBoot: false
+```
+
+### SNP with static hostData
+
+```yaml
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+spec:
+  template:
+    spec:
+      domain:
+        launchSecurity:
+          sevSnp:
+            hostData: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+        firmware:
+          bootloader:
+            efi:
+              secureBoot: false
+```
+
+### TDX with dynamic injection (external operator)
+
+When the values are provisioned at runtime by an external operator, the VMI
+is created with `attestation` and `startStrategy: Paused`. The operator
+calls the subresource after the VMI reaches the `Scheduled` phase:
+
+```yaml
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+spec:
+  template:
+    spec:
+      startStrategy: Paused
+      domain:
+        launchSecurity:
+          tdx:
+            attestation: {}
+        firmware:
+          bootloader:
+            efi:
+              secureBoot: false
+```
+
+```bash
+curl -X PUT \
+  /apis/subresources.kubevirt.io/v1/namespaces/default/virtualmachineinstances/my-vm/tdx/injectInitdata \
+  -H "Content-Type: application/json" \
+  -d '{
+    "mrConfigId": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+    "oemStrings": ["kbs:///default/uuid/root"]
+  }'
+```
+
+### SNP with dynamic injection (external operator)
+
+```yaml
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+spec:
+  template:
+    spec:
+      startStrategy: Paused
+      domain:
+        launchSecurity:
+          sevSnp:
+            attestation: {}
+        firmware:
+          bootloader:
+            efi:
+              secureBoot: false
+```
+
+```bash
+curl -X PUT \
+  /apis/subresources.kubevirt.io/v1/namespaces/default/virtualmachineinstances/my-vm/snp/injectInitdata \
+  -H "Content-Type: application/json" \
+  -d '{
+    "hostData": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+    "oemStrings": ["kbs:///default/uuid/root"]
+  }'
+```
+
+## Alternatives
+
+### Hook sidecar
+
+The current approach used before this proposal. A hook sidecar intercepts
+the libvirt domain XML at VMI creation time and modifies it directly to inject
+`mrConfigId`/`hostData` and OEM strings.
+
+**Drawbacks:** bypasses KubeVirt's API, not auditable, no RBAC, fragile
+against KubeVirt upgrades that change the XML structure, requires a sidecar
+container per VMI.
+
+### KubeVirt-internal provisioner
+
+KubeVirt itself could contact the provisioner service instead of relying on
+an external operator.
+
+**Drawbacks:** couples KubeVirt to a specific provisioner implementation and
+contradicts the existing SEV model where KubeVirt only provides plumbing.
+
+## Scalability
+
+The subresource adds one `PUT` call per VMI creation (or two if counting
+`unpause`). This is comparable to the existing SEV attestation flow and does
+not introduce new watchers or polling loops in KubeVirt itself. The external
+operator's scalability is its own concern.
+
+## Update/Rollback Compatibility
+
+- The new fields (`mrConfigId`, `hostData`, `oemStrings`, `attestation`) are
+  optional and default to empty/nil. Existing VMI specs are unaffected.
+- The subresource endpoints are guarded by the existing feature gates
+  `WorkloadEncryptionTDX` and `WorkloadEncryptionSEVSNP`. Disabling the
+  feature gate removes access to the endpoints without affecting existing VMs.
+- Rollback to a version without this feature is safe: the new fields are
+  ignored by older versions and VMs that do not set `attestation` behave
+  identically to before.
+
+## Functional Testing Approach
+
+- Unit tests for the `TDXInjectInitdataHandler` and `SNPInjectInitdataHandler`:
+  valid injection, duplicate injection rejection, wrong phase rejection,
+  invalid base64, wrong byte length.
+- Unit tests for `shouldWaitForTDXAttestation` and
+  `shouldWaitForSNPAttestation` in `virt-handler`.
+- Unit tests for libvirt XML converter verifying `mrConfigId`, `hostData`, and
+  `oemStrings` appear in the generated XML.
+- Admission webhook tests verifying that `attestation` without
+  `startStrategy: Paused` is rejected.
+- E2E test with a sample attester: create a TDX/SNP VMI with `attestation`,
+  call the subresource, verify the VMI transitions through
+  `Scheduled` → `Running` → unpaused.
+
+## Graduation Requirements
+
+### Alpha
+
+The feature will be implemented in Alpha. We do not know if it will be possible
+to have e2e tests in Alpha due to lack of TDX hardware. We expect the feature
+to be merged without the e2e tests.
+
+### Beta
+
+We expect e2e tests in Beta. We expect the API to be stable.
+
+### GA

--- a/veps/sig-compute/340-launchsecurity-inject-initdata/injectinitdata-proposal.md
+++ b/veps/sig-compute/340-launchsecurity-inject-initdata/injectinitdata-proposal.md
@@ -1,0 +1,353 @@
+# VEP #340: launchsecurity: Add InitData resource for TDX and SNP
+
+## VEP Status Metadata
+
+### Target releases (InitData)
+
+- This VEP targets alpha for version: v1.11
+- This VEP targets beta for version:
+- This VEP targets GA for version:
+
+### Release Signoff Checklist
+
+Items marked with (R) are required *prior to targeting to a milestone / release*.
+
+- [ ] (R) Enhancement issue created, which links to VEP dir in [kubevirt/enhancements] (not the initial VEP PR)
+- [x] (R) Alpha target version is explicitly mentioned and approved
+- [ ] (R) Beta target version is explicitly mentioned and approved
+- [ ] (R) GA target version is explicitly mentioned and approved
+
+## Overview
+
+Confidential VMs (CVMs) require per-VM configuration values to be injected
+before boot so the guest can use them during remote attestation. These values
+are incorporated into hardware measurement registers and become part of the
+attestation report, allowing the guest to prove that the host provided the
+expected configuration.
+
+This proposal introduces a new `InitData` Custom Resource (CR) that carries
+the launch-time attestation values for a VMI.
+
+The design cleanly separates two concerns:
+
+1. **Immutable intent** in the VMI spec (`initDataRef` field).
+2. **One-shot launch-data commitment** in the `InitData` CR (write-once, referenced from VMI spec).
+
+In this VEP, InitData wording refers to
+[initData](https://github.com/confidential-containers/trustee/blob/main/kbs/docs/initdata.md).
+The Initdata Specification defines the key data structure and algorithms to
+inject any well-defined data from untrusted host into TEE.
+
+## Motivation
+
+Organizations deploying confidential VMs need the strongest possible
+attestation guarantees. A key use case is encrypted disk provisioning: an
+external operator injects a reference to a secret stored in a Key Broker
+Service (KBS) into the guest before boot. The guest then attests to the KBS
+and retrieves the secret only if the attestation passes. The injected values
+become part of the hardware measurement, ensuring the host cannot tamper with
+them undetected.
+
+## Goals
+
+- Expose TDX and SEV-SNP InitData fields through the CR
+- Provide a declarative, Kubernetes-native mechanism for InitData commitment
+  that is compatible with GitOps workflows.
+
+## Non Goals
+
+- Implement the external operator that creates `InitData` resources.
+- Verify the cryptographic relationship between the digest and the InitData bytes.
+
+## Definition of Users
+
+- Cluster Administrators: Configure RBAC permissions for the `InitData`
+  resource.
+
+- VM Users: Secret delivery.
+
+## User Stories
+
+- As a VM user, I want to tell the infrastructure to inject InitData into my
+  confidential VM.
+
+## Repos
+
+- [kubevirt/kubevirt](https://github.com/kubevirt/kubevirt)
+
+## Design
+
+The design separates immutable declarative intent (VMI spec) and one-shot
+launch-data commitment (`InitData` CR).
+
+### API extensions
+
+New fields added to the VMI spec. These are set at creation time and never
+mutated:
+
+```go
+type TDX struct {
+    InitDataRef string `json:"initDataRef,omitempty"`
+}
+
+type SEVSNP struct {
+    InitDataRef string `json:"initDataRef,omitempty"`
+}
+```
+### InitData CRD
+
+A new namespace-scoped Custom Resource that carries the launch-time values:
+
+```go
+type InitData struct {
+    metav1.TypeMeta   `json:",inline"`
+    metav1.ObjectMeta `json:"metadata,omitempty"`
+    Spec   InitDataSpec   `json:"spec"`
+    Status InitDataStatus `json:"status,omitempty"`
+}
+
+type InitDataSpec struct {
+    // TDX: base64-encoded 48-byte digest. Mutually exclusive with HostData.
+    MRConfigId string `json:"mrConfigId,omitempty"`
+    // SNP: base64-encoded 32-byte digest. Mutually exclusive with MRConfigId.
+    HostData string `json:"hostData,omitempty"`
+    // Init-Data bytes delivered via SMBIOS Type 11.
+    OEMStrings []string `json:"oemStrings"`
+}
+
+type InitDataStatus struct {
+    Conditions []metav1.Condition `json:"conditions,omitempty"`
+}
+
+```
+
+Properties:
+- The `InitData` CR has an `ownerReference` pointing to the VMI, enabling
+  automatic garbage collection when the VMI is deleted.
+- **Write-once**: updates to `.spec` are rejected after the `InitData` has
+  reached `Committed`.
+
+### Validation Rules
+
+- `InitData` update to `.spec` after committed condition is True : InitData -
+  rejected (write-once)
+
+### Security Considerations
+
+- The `InitData` resource is guarded by RBAC. Only components with the
+  appropriate ClusterRole can create `InitData` resources. RBAC restricts
+  which components can supply launch-data (access control).
+- The committed `mrConfigId` and `hostData` are measured by the hardware (TDX
+  or SEV-SNP respectively). Any tampering is detectable by the guest during
+  remote attestation. The host infrastructure provider cannot modify these
+  values after commitment without invalidating the attestation report.
+- The `oemStrings` field carries a reference (e.g., a KBS resource path), not
+  the actual secret. The secret is only released by the KBS after the guest
+  passes attestation.
+- The `InitData` CR contains measurement digests and resource paths, not
+  cryptographic keys.
+
+## API Examples
+
+### TDX
+
+Values are provisioned at runtime, the VMI is created with `initDataRef`.
+KubeVirt blocks VM startup until a committed `InitData` CR is available.
+
+```yaml
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: my-tdx-vm
+spec:
+  template:
+    spec:
+      domain:
+        launchSecurity:
+          tdx:
+            initDataRef: my-tdx-vm-initdata
+        firmware:
+          bootloader:
+            efi:
+              secureBoot: false
+```
+
+InitData CR:
+
+```yaml
+apiVersion: kubevirt.io/v1
+kind: InitData
+metadata:
+  name: my-tdx-vm-initdata
+  namespace: default
+  ownerReferences:
+    - apiVersion: kubevirt.io/v1
+      kind: VirtualMachineInstance
+      name: my-tdx-vm
+      uid: "a1b2c3d4-e5f6-..."
+spec:
+  mrConfigId: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+  oemStrings:
+    - "kbs:///default/uuid/root"
+```
+
+### SNP
+
+```yaml
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: my-snp-vm
+spec:
+  template:
+    spec:
+      domain:
+        launchSecurity:
+          sevSnp:
+            initDataRef: my-snp-vm-initdata
+        firmware:
+          bootloader:
+            efi:
+              secureBoot: false
+```
+
+InitData CR:
+
+```yaml
+apiVersion: kubevirt.io/v1
+kind: InitData
+metadata:
+  name: my-snp-vm-initdata
+  namespace: default
+  ownerReferences:
+    - apiVersion: kubevirt.io/v1
+      kind: VirtualMachineInstance
+      name: my-snp-vm
+      uid: "f7e8d9c0-b1a2-..."
+spec:
+  hostData: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+  oemStrings:
+    - "kbs:///default/uuid/root"
+```
+
+## Alternatives
+
+### Subresource-based injection
+
+**Drawbacks:**
+- Mutating the VMI spec at runtime causes GitOps configuration drift.
+- Imperative one-shot PUT calls are not aligned with Kubernetes declarative
+  patterns.
+- JSON Patch with `test` operations for concurrency control is fragile.
+- Field ownership between the user (static values) and the operator (dynamic
+  values) is ambiguous when both live in the same spec field.
+
+### Hook sidecar
+
+A hook sidecar intercepts the libvirt domain XML at VMI creation time and
+modifies it directly to inject `mrConfigId`/`hostData` and OEM strings.
+
+**Drawbacks:** bypasses KubeVirt's API, not auditable, no RBAC, fragile
+against KubeVirt upgrades that change the XML structure, requires a sidecar
+container per VMI.
+
+### KubeVirt-internal provisioner
+
+KubeVirt itself could contact the provisioner service instead of relying on
+an external operator.
+
+**Drawbacks:** couples KubeVirt to a specific provisioner implementation and
+contradicts the existing SEV model where KubeVirt only provides plumbing.
+
+## Scalability
+
+The `InitData` controller adds one watch and one reconcile per VMI creation.
+The controller does not poll; it reacts to `InitData` creation events.
+
+## Update/Rollback Compatibility
+
+- The new VMI spec fields initDataRef are optional and default to empty/nil.
+  Existing VMI specs are unaffected.
+- The `InitData` CRD does not exist in older versions. Rollback removes the
+  CRD; existing `InitData` objects are garbage-collected with their owning
+  VMIs.
+- The feature is guarded by the `InjectInitData` feature gate.
+
+## Functional Testing Approach
+
+- Unit tests for the `InitData`: Duplicate `InitData` rejection, write-once
+  enforcement, invalid base64, wrong byte length, `MRConfigId`/`HostData`
+  mutual exclusivity.
+- Unit tests for the blocking logic that waits for a committed `InitData` CR
+  before starting the VM.
+- E2E test: create a TDX/SNP VMI with `initDataRef`, create an `InitData` CR,
+  verify the VMI transitions from `Scheduled` to `Running` only after the
+  `InitData` reaches `Committed`.
+
+## Trust Model and Security Contract
+
+### Normative InitData Chain
+
+The complete trust chain for Init-Data follows the
+[CoCo Init-Data specification](https://confidentialcontainers.org/docs/features/initdata/#integrity-and-attestation):
+
+1. **InitData bytes** — The provisioner constructs the InitData TOML payload
+   (containing policy, AA/CDH configuration, or KBS resource paths).
+
+2. **Canonical digest** — The provisioner computes the digest using the
+   algorithm declared in the InitData TOML (`sha384` for TDX, `sha256` for
+   SNP).
+
+3. **Launch register commitment** — KubeVirt writes the digest to the hardware
+   launch register via libvirt and delivers the InitData bytes via SMBIOS Type
+   11 (`oemStrings`). **This is KubeVirt's sole role: atomic transport and
+   commitment.** KubeVirt does not verify the relationship between the digest
+   and the delivered bytes.
+
+4. **Guest verify-before-parse** — The guest Attestation Agent computes
+   `hash(SMBIOS Type 11 data)` and compares it with the value in its own
+   hardware report (`TDREPORT.MR_CONFIG_ID` or SNP attestation report
+   `HOSTDATA`). If mismatch, the guest MUST abort. The guest MUST NOT parse or
+   act on the InitData before this verification succeeds.
+
+5. **Attestation Service claim** — During remote attestation, the Attestation
+   Service verifies the hardware evidence and includes the InitData digest as a
+   verified claim in the attestation token.
+
+6. **Relying-party / KBS policy authorization** — The KBS evaluates the
+   verified claims (including the specific `mrConfigId`/`hostData` value)
+   against its resource release policy. Only if the policy authorizes the
+   digest does the KBS release the requested secret.
+
+KubeVirt operates exclusively at step 3. It does not interpret the InitData
+content, does not verify digests, and MUST NOT be treated as an authority that
+establishes attestation success.
+
+### InitData Representation
+
+`mrConfigId` MUST be the SHA-384 digest of the InitData bytes delivered via
+`oemStrings`. For SEV-SNP, `hostData` MUST be the SHA-256 digest of the same
+payload.
+
+### Negative Cases
+
+- If the guest detects `hash(SMBIOS) != TDREPORT.mrConfigId` then MUST abort.
+- If the KBS does not recognize the `mrConfigId` then MUST NOT release the key.
+- If an `InitData` CR is created with a `mrConfigId` that does not correspond
+  to the `oemStrings` then KubeVirt does not detect this (out of scope); the
+  guest and KBS reject it at attestation time.
+- If no `InitData` CR is created or validation fails then the VMI remains in
+  `Scheduled` phase indefinitely; it never boots without valid InitData.
+
+## Graduation Requirements
+
+### Alpha
+
+The feature will be implemented in Alpha.
+
+### Beta
+
+We expect e2e tests in Beta. We expect the API to be stable.
+
+### GA
+Remove feature gate


### PR DESCRIPTION
Add InitData resource for TDX and SNP

### VEP Metadata

**Tracking issue**: https://github.com/kubevirt/enhancements/issues/340
**SIG label**: /sig compute

### What this PR does
<!-- Please summarize the VEP update here -->

Add VEP about the injection of mrConfig (TDX) and hostData(SEV-SNP). These registers are used to carry a checksum of the initData used during attestation (see https://github.com/confidential-containers/trustee/blob/main/kbs/docs/initdata.md)

### Special notes for your reviewer
