### PR TITLE
VEP 285: Add Beta Target and update history with alpha PRs

### DIFF
--- a/veps/sig-compute/285-launchsecurity-preference/launchsecurity-preference.md
+++ b/veps/sig-compute/285-launchsecurity-preference/launchsecurity-preference.md
@@ -14,7 +14,7 @@ For example, during the planning phase for version v1.123, do **not** target bet
 -->
 
 - This VEP targets alpha for version: v1.9.0
-- This VEP targets beta for version:
+- This VEP targets beta for version: v1.10.0
 - This VEP targets GA for version:
 
 ### Release Signoff Checklist
@@ -23,7 +23,7 @@ Items marked with (R) are required *prior to targeting to a milestone / release*
 
 - [x] (R) Enhancement issue created, which links to VEP dir in [kubevirt/enhancements] (not the initial VEP PR)
 - [x] (R) Alpha target version is explicitly mentioned and approved
-- [ ] (R) Beta target version is explicitly mentioned and approved
+- [x] (R) Beta target version is explicitly mentioned and approved
 - [ ] (R) GA target version is explicitly mentioned and approved
 
 ## Overview
@@ -191,7 +191,8 @@ features.
 
 ## Implementation History
 
-- **21-04-2026:** Created VEP proposal and PoC PR
+- **21-04-2026:** Created [VEP proposal](https://github.com/kubevirt/enhancements/pull/286) and PoC PR
+- **14-06-2026:** [Merged initial implementation and API changes](https://github.com/kubevirt/kubevirt/pull/17551)
 
 ## Graduation Requirements
 
@@ -212,10 +213,10 @@ Refer to https://github.com/kubevirt/community/blob/main/design-proposals/featur
 -->
 
 ### Alpha
-- [ ] API changes are implemented and available
-- [ ] New preference field is applied when rendering VMI
-- [ ] Unit tests are implemented and passing
-- [ ] Added deprecation notice for `launchSecurity` field in `VirtualMachineInstanceSpec`
+- [x] API changes are implemented and available
+- [x] New preference field is applied when rendering VMI
+- [x] Unit tests are implemented and passing
+- [x] Added deprecation notice for `launchSecurity` field in `VirtualMachineInstanceSpec`
 
 ### Beta
 - [ ] `VirtualMachineClusterPreferences` for IBM Secure Execution are added to common-instancetypes

--- a/veps/sig-compute/285-launchsecurity-preference/vep.md
+++ b/veps/sig-compute/285-launchsecurity-preference/vep.md
@@ -14,7 +14,7 @@ For example, during the planning phase for version v1.123, do **not** target bet
 -->
 
 - This VEP targets alpha for version: v1.9.0
-- This VEP targets beta for version:
+- This VEP targets beta for version: v1.10.0
 - This VEP targets GA for version:
 
 ### Release Signoff Checklist
@@ -23,7 +23,7 @@ Items marked with (R) are required *prior to targeting to a milestone / release*
 
 - [x] (R) Enhancement issue created, which links to VEP dir in [kubevirt/enhancements] (not the initial VEP PR)
 - [x] (R) Alpha target version is explicitly mentioned and approved
-- [ ] (R) Beta target version is explicitly mentioned and approved
+- [x] (R) Beta target version is explicitly mentioned and approved
 - [ ] (R) GA target version is explicitly mentioned and approved
 
 ## Overview
@@ -191,7 +191,8 @@ features.
 
 ## Implementation History
 
-- **21-04-2026:** Created VEP proposal and PoC PR
+- **21-04-2026:** Created [VEP proposal](https://github.com/kubevirt/enhancements/pull/286) and PoC PR
+- **14-06-2026:** [Merged initial implementation and API changes](https://github.com/kubevirt/kubevirt/pull/17551)
 
 ## Graduation Requirements
 
@@ -212,10 +213,10 @@ Refer to https://github.com/kubevirt/community/blob/main/design-proposals/featur
 -->
 
 ### Alpha
-- [ ] API changes are implemented and available
-- [ ] New preference field is applied when rendering VMI
-- [ ] Unit tests are implemented and passing
-- [ ] Added deprecation notice for `launchSecurity` field in `VirtualMachineInstanceSpec`
+- [x] API changes are implemented and available
+- [x] New preference field is applied when rendering VMI
+- [x] Unit tests are implemented and passing
+- [x] Added deprecation notice for `launchSecurity` field in `VirtualMachineInstanceSpec`
 
 ### Beta
 - [ ] `VirtualMachineClusterPreferences` for IBM Secure Execution are added to common-instancetypes


### PR DESCRIPTION
Target 1.10 for beta phase.
Add implementation history for alpha stage.

### VEP Metadata

**Tracking issue**: <!-- For example, https://github.com/kubevirt/enhancements/pull/2 --> https://github.com/kubevirt/enhancements/issues/285
**SIG label**: <!-- For example, /sig $SIG --> /sig compute

### What this PR does
<!-- Please summarize the VEP update here -->

### Special notes for your reviewer
