### PR TITLE
VEP #362: Guest Termination State

### DIFF
--- a/veps/sig-compute/362-guest-termination-state/vep.md
+++ b/veps/sig-compute/362-guest-termination-state/vep.md
@@ -1,0 +1,456 @@
+# VEP #362: Guest Termination State
+
+## VEP Status Metadata
+
+### Target releases
+
+- This VEP targets alpha for version: 1.10
+- This VEP targets beta for version:
+- This VEP targets GA for version:
+
+### Release Signoff Checklist
+
+Items marked with (R) are required *prior to targeting to a milestone / release*.
+
+- [x] (R) Enhancement issue created, which links to VEP dir in [kubevirt/enhancements] (not the initial VEP PR)
+- [ ] (R) Alpha target version is explicitly mentioned and approved
+- [ ] (R) Beta target version is explicitly mentioned and approved
+- [ ] (R) GA target version is explicitly mentioned and approved
+
+## Overview
+
+KubeVirt can observe several different ways in which a guest or its domain stops:
+shutdown initiated from inside the guest, KubeVirt/API requested shutdown,
+hypervisor-side stop, and guest crash/panic. Today these cases are mostly
+reflected through generic VMI phase and readiness condition. For example, a guest
+shutdown can eventually appear as `phase: Succeeded` with
+`Ready=False, reason=GuestNotRunning`, while other stop paths may surface as
+generic failure, pod termination, or Kubernetes events.
+
+This proposal introduces a normalized guest termination state in the KubeVirt API.
+The state records the observed reason, message, and timestamp for a terminated
+guest/domain lifecycle. A VM-level copy also records the source VMI UID so the
+reason remains meaningful after the VMI object is deleted or replaced. It is
+intended as a durable, machine-readable source of truth for users and
+higher-level controllers that need to understand why a VM stopped.
+
+The public API is hypervisor-agnostic. Current libvirt lifecycle events are used
+only as one implementation source for populating the normalized reasons.
+
+## Motivation
+
+Users and automation often need to distinguish expected guest behavior from
+infrastructure or platform behavior. Examples:
+
+- A user runs `shutdown now` inside the guest and expects to understand that the
+  VM stopped because the guest requested it.
+- A user or controller requests a VM stop through KubeVirt and expects that stop
+  to be distinguishable from a shutdown initiated inside the guest.
+- A guest kernel panic should be observable as a guest crash instead of being
+  conflated with ordinary shutdown.
+- Higher-level platforms built on KubeVirt need a stable status surface to decide
+  whether to recover, report, alert, bill, or leave an instance stopped.
+
+Prior discussions and features address adjacent behavior but not a structured
+termination reason API:
+
+- Guest shutdown behavior and RunStrategy decide what KubeVirt should do after a
+  guest stops, but not why the guest stopped.
+- `rebootPolicy` makes guest reboot visible to KubeVirt when requested, but does
+  not expose the reason for a terminated guest/domain lifecycle.
+- Guest panic support emits Kubernetes events ([#16666](https://github.com/kubevirt/kubevirt/pull/16666))
+  and metrics ([#17836](https://github.com/kubevirt/kubevirt/pull/17836)) for one crash class,
+  but there is no general termination state covering shutdown and stop causes.
+
+## Goals
+
+- Add a normalized guest/domain termination state to VMI status.
+- Add a VM-level last termination state copied from the latest relevant VMI so
+  the reason remains visible after the VMI is deleted.
+- Distinguish at least:
+  - guest-initiated shutdown
+  - KubeVirt/API requested shutdown
+  - host/hypervisor requested shutdown
+  - host/hypervisor observed unexpected stop/failure
+  - guest crash/panic
+- Keep the public API independent from libvirt event names.
+- Preserve an observed termination reason across later low-signal terminal
+  domain notifications in the same domain lifecycle.
+- Emit a Kubernetes event when a guest termination state is observed.
+- Expose metrics for observed guest termination reasons.
+- Guard the initial implementation behind a feature gate.
+
+## Non Goals
+
+- This proposal does not change RunStrategy semantics.
+- This proposal does not change `rebootPolicy` semantics.
+- This proposal does not introduce a recovery policy or automatic restart policy.
+- This proposal does not make `Ready` condition carry historical termination state.
+- This proposal does not guarantee attribution for node crashes where the
+  virt-launcher process and hypervisor event stream are lost before an event can
+  be observed.
+- This proposal does not expose libvirt event names as KubeVirt API values.
+
+## Definition of Users
+
+- VM owners who need to understand why their VM stopped.
+- Cluster administrators and SREs investigating VM lifecycle incidents.
+- Higher-level controllers and platforms built on KubeVirt.
+- Monitoring and UI systems that need a stable source of VM stop attribution.
+- KubeVirt developers debugging guest/domain lifecycle behavior.
+
+## User Stories
+
+- As a VM owner, I want to see that my VM stopped because the guest OS requested
+  shutdown, so I can distinguish expected in-guest behavior from a failure.
+- As a cluster administrator, I want guest crashes to be distinguishable from
+  platform-requested shutdown, so alerts and dashboards can report the right
+  cause.
+- As a higher-level controller, I want a machine-readable stop reason after the
+  VMI has disappeared, so I can make recovery decisions based on the last VMI
+  lifecycle.
+- As a KubeVirt developer, I want a normalized status field instead of relying on
+  libvirt-specific lifecycle detail names, so the API can survive future
+  hypervisor implementation changes.
+
+## Repos
+
+kubevirt/kubevirt
+
+## Design
+
+### API
+
+Introduce a VMI-scoped termination state:
+
+```go
+type VirtualMachineInstanceTerminationState struct {
+    // Reason is a short, stable, machine-readable termination reason.
+    // +optional
+    Reason VirtualMachineInstanceTerminationReason `json:"reason,omitempty"`
+
+    // Message is a human-readable explanation of the observed termination.
+    // +optional
+    Message string `json:"message,omitempty"`
+
+    // Timestamp is the time at which KubeVirt observed the termination event.
+    // +optional
+    Timestamp metav1.Time `json:"timestamp,omitempty"`
+}
+
+type VirtualMachineInstanceTerminationReason string
+
+const (
+    VirtualMachineInstanceTerminationReasonGuestShutdown              VirtualMachineInstanceTerminationReason = "GuestShutdown"
+    VirtualMachineInstanceTerminationReasonPlatformRequestedShutdown  VirtualMachineInstanceTerminationReason = "PlatformRequestedShutdown"
+    VirtualMachineInstanceTerminationReasonHostShutdown               VirtualMachineInstanceTerminationReason = "HostShutdown"
+    VirtualMachineInstanceTerminationReasonHostStoppedFailed          VirtualMachineInstanceTerminationReason = "HostStoppedFailed"
+    VirtualMachineInstanceTerminationReasonGuestCrashed               VirtualMachineInstanceTerminationReason = "GuestCrashed"
+)
+```
+
+Add it to VMI status:
+
+```go
+type VirtualMachineInstanceStatus struct {
+    // TerminationState reports the observed termination state for this VMI
+    // lifecycle.
+    // +optional
+    TerminationState *VirtualMachineInstanceTerminationState `json:"terminationState,omitempty"`
+}
+```
+
+Add a VM-level copy that includes the VMI UID:
+
+```go
+type VirtualMachineTerminationState struct {
+    // VMIUID identifies the VMI lifecycle this termination state came from.
+    // +optional
+    VMIUID types.UID `json:"vmiUID,omitempty"`
+
+    // Reason is a short, stable, machine-readable termination reason.
+    // +optional
+    Reason VirtualMachineInstanceTerminationReason `json:"reason,omitempty"`
+
+    // Message is a human-readable explanation of the observed termination.
+    // +optional
+    Message string `json:"message,omitempty"`
+
+    // Timestamp is the time at which KubeVirt observed the termination event.
+    // +optional
+    Timestamp metav1.Time `json:"timestamp,omitempty"`
+}
+
+type VirtualMachineStatus struct {
+    // LastTerminationState reports the latest observed termination state copied
+    // from a VMI owned by this VM.
+    // +optional
+    LastTerminationState *VirtualMachineTerminationState `json:"lastTerminationState,omitempty"`
+}
+```
+
+The VMI field is the authoritative state for a specific VMI lifecycle. The VM
+field is a durable copy for user-facing inspection after the VMI is deleted. The
+`vmiUID` field prevents consumers from accidentally treating a previous VMI
+lifecycle as the current one.
+
+### Reason semantics
+
+`GuestShutdown` means the guest OS requested shutdown/poweroff and KubeVirt
+observed a normal guest termination.
+
+`PlatformRequestedShutdown` means KubeVirt requested domain shutdown as part of
+VM/VMI stop or deletion flow and the observed termination corresponds to that
+request.
+
+`HostShutdown` means the hypervisor host side requested shutdown or destroy, but
+KubeVirt did not associate the event with a tracked platform shutdown request.
+
+`HostStoppedFailed` means the hypervisor reported that the domain stopped
+unexpectedly or failed without a more specific guest crash signal.
+
+`GuestCrashed` means the guest reported or triggered a crash/panic signal.
+
+The exact names are open to SIG review. The important contract is that the
+reason values are normalized KubeVirt concepts, not libvirt event names.
+
+### Event collection
+
+The initial implementation can derive the normalized state from the existing
+virt-launcher to virt-handler domain status flow.
+
+virt-launcher records normalized termination events in the internal domain status
+sent to virt-handler. This internal value is not the public API. It is a
+transport detail used so virt-handler can update the VMI/VM API, emit events, and
+increment metrics.
+
+Current libvirt mapping:
+
+| Libvirt event | Libvirt detail | Normalized reason |
+|---------------|----------------|-------------------|
+| `DOMAIN_EVENT_SHUTDOWN` | `DOMAIN_EVENT_SHUTDOWN_GUEST` | `GuestShutdown`, unless matched to a pending KubeVirt shutdown intent |
+| `DOMAIN_EVENT_SHUTDOWN` | `DOMAIN_EVENT_SHUTDOWN_HOST` | `HostShutdown`, unless matched to a pending KubeVirt shutdown intent |
+| `DOMAIN_EVENT_CRASHED` | `DOMAIN_EVENT_CRASHED_PANICKED` | `GuestCrashed` |
+| `DOMAIN_EVENT_CRASHED` | `DOMAIN_EVENT_CRASHED_CRASHLOADED` | `GuestCrashed` |
+| `DOMAIN_EVENT_STOPPED` | `DOMAIN_EVENT_STOPPED_CRASHED` | `GuestCrashed` |
+| `DOMAIN_EVENT_STOPPED` | `DOMAIN_EVENT_STOPPED_FAILED` | `HostStoppedFailed` |
+| `DOMAIN_EVENT_STOPPED` | `DOMAIN_EVENT_STOPPED_DESTROYED` | no new reason |
+| `DOMAIN_EVENT_STOPPED` | `DOMAIN_EVENT_STOPPED_SHUTDOWN` | no new reason |
+| `DOMAIN_EVENT_STOPPED` | `DOMAIN_EVENT_STOPPED_MIGRATED` | no new reason |
+
+`DOMAIN_EVENT_STOPPED_CRASHED` may refine or overwrite a preceding
+`DOMAIN_EVENT_CRASHED_*` event because it confirms that the domain has stopped.
+
+`PlatformRequestedShutdown` is detected by recording a pending KubeVirt shutdown
+intent when virt-launcher issues the shutdown request on behalf of KubeVirt. The
+intent is consumed by the next matching shutdown event. The intent is considered
+fresh for the larger of a default freshness window and the VMI termination grace
+period plus a small margin. A stale intent is cleared and ignored.
+
+### Sticky internal domain termination event
+
+Some domain lifecycles produce a useful first event followed by a later terminal
+event that does not carry enough information by itself. For example:
+
+- guest shutdown: `SHUTDOWN_GUEST` followed by `STOPPED_SHUTDOWN`
+- platform-requested shutdown: `SHUTDOWN_GUEST` or `SHUTDOWN_HOST` matched to a
+  pending platform intent, followed by `STOPPED_SHUTDOWN` or `STOPPED_DESTROYED`
+- guest crash: `CRASHED_PANICKED` followed by `STOPPED_CRASHED`
+
+To avoid losing the useful reason during the final domain notification,
+virt-launcher keeps the last observed normalized termination event in its
+per-launcher metadata cache. When a later domain notification does not map to a
+new normalized reason, virt-launcher attaches the cached event to the domain
+status sent to virt-handler.
+
+The cached event is scoped to one virt-launcher/domain lifecycle. It is cleared
+when a `DOMAIN_EVENT_STARTED` event is observed. The same start event also clears
+any pending platform termination intent. This prevents a termination reason from
+leaking into a fresh domain incarnation.
+
+If a low-signal terminal event is observed without any cached normalized event,
+KubeVirt does not infer a termination reason from it. This avoids turning
+ambiguous terminal states into misleading user-visible attribution.
+
+### VM propagation
+
+When a VMI owned by a VM has `status.terminationState`, virt-controller copies it
+to `vm.status.lastTerminationState` with the source VMI UID.
+
+The VM field is intentionally named `lastTerminationState` because it is
+historical. It is not a statement that the current VMI, if one exists, is
+terminated.
+
+### Kubernetes events
+
+When KubeVirt observes a normalized termination state, it emits a Kubernetes
+event on the VMI:
+
+- Event type `Normal` for expected shutdown reasons.
+- Event type `Warning` for crash or unexpected stop reasons.
+- Event reason is the normalized termination reason.
+- Event message is the same human-readable message used in status.
+
+### Metrics
+
+Expose a counter for observed guest termination states:
+
+```text
+kubevirt_vmi_guest_os_termination_total{namespace, name, reason}
+```
+
+The metric follows the precedent of guest panic metrics and allows operators to
+track fleet-wide termination causes. Implementations should avoid adding
+high-cardinality detail labels such as raw hypervisor messages.
+
+## API Examples
+
+Guest shutdown visible on the VMI:
+
+```yaml
+apiVersion: kubevirt.io/v1
+kind: VirtualMachineInstance
+metadata:
+  name: fedora
+  namespace: default
+  uid: 7d5f0d4d-3df8-442f-bd64-9ee9d0f6fb8e
+status:
+  phase: Succeeded
+  terminationState:
+    reason: GuestShutdown
+    message: Guest requested shutdown of the virtual machine
+    timestamp: "2026-06-15T12:00:00Z"
+```
+
+The same reason copied to the VM after the VMI is gone:
+
+```yaml
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: fedora
+  namespace: default
+status:
+  printableStatus: Stopped
+  lastTerminationState:
+    vmiUID: 7d5f0d4d-3df8-442f-bd64-9ee9d0f6fb8e
+    reason: GuestShutdown
+    message: Guest requested shutdown of the virtual machine
+    timestamp: "2026-06-15T12:00:00Z"
+```
+
+Guest crash:
+
+```yaml
+status:
+  terminationState:
+    reason: GuestCrashed
+    message: Guest crashed
+    timestamp: "2026-06-15T12:05:00Z"
+```
+
+Platform requested shutdown:
+
+```yaml
+status:
+  terminationState:
+    reason: PlatformRequestedShutdown
+    message: Platform requested shutdown of the virtual machine
+    timestamp: "2026-06-15T12:10:00Z"
+```
+
+## Alternatives
+
+### Use the Ready condition
+
+`Ready` already reports `GuestNotRunning`, `PodTerminating`, and other
+availability states. It is not a good fit for termination attribution because it
+is transient, availability-oriented, and can copy pod readiness reasons directly.
+`GuestNotRunning` also covers startup and other non-running windows, not only
+guest termination.
+
+### Add a GuestTerminated condition
+
+A condition is useful for current state, but less suitable for durable historical
+state. It also creates awkward behavior across VM restarts: a `True` condition can
+look current even when it describes a previous VMI lifecycle. A structured status
+field with source `vmiUID` is clearer for "last observed termination".
+
+### Store the reason only on the VM
+
+The VM is the best user-facing place after the VMI is deleted, but the VMI is the
+natural authoritative object for a specific domain lifecycle. Keeping both fields
+allows controllers to reason about the current VMI lifecycle while still
+preserving a durable VM-level copy.
+
+### Use only Kubernetes events or metrics
+
+Events and metrics are useful for observability, but they are not a stable API
+source of truth for controllers. Events can expire and metrics are eventually
+scraped. Status is the right API surface for current and last observed state.
+
+## Scalability
+
+The status fields are small and updated only when KubeVirt observes a guest/domain
+termination event. The metric adds one counter series per observed VMI and reason,
+matching existing KubeVirt per-VMI metric patterns. Implementations should avoid
+labels derived from raw messages, domain names, or crash payloads.
+
+## Update/Rollback Compatibility
+
+This is an additive status API and is backward compatible.
+
+During upgrade, new KubeVirt components begin populating the optional status
+fields when the feature gate is enabled. Older clients ignore the new fields.
+
+During rollback, older KubeVirt components stop updating the fields. Existing
+status values may remain until the object is updated or recreated. Consumers must
+treat the fields as optional.
+
+The initial implementation should be guarded by a feature gate, tentatively named
+`GuestTermination`.
+
+## Functional Testing Approach
+
+- Unit test mapping from hypervisor lifecycle events to normalized termination
+  reasons.
+- Unit test pending KubeVirt shutdown intent matching and stale intent cleanup.
+- Unit test that later low-signal domain notifications preserve the cached
+  normalized termination event.
+- Unit test that domain start clears stale in-launcher termination state and
+  pending platform termination intent.
+- Unit test VMI status updates for each normalized reason.
+- Unit test VM propagation from VMI `terminationState` to VM
+  `lastTerminationState`.
+- Functional test guest-initiated shutdown from inside a Linux guest.
+- Functional test KubeVirt/API requested VM stop or VMI deletion.
+- Functional test guest panic when panic devices are available.
+- Functional test unexpected hypervisor stop/failure path where practical.
+- Verify no status, event, or metric is emitted when the feature gate is disabled.
+
+## Implementation History
+
+## Graduation Requirements
+
+### Alpha
+
+- [ ] Feature gate added.
+- [ ] VMI `status.terminationState` API added.
+- [ ] VM `status.lastTerminationState` API added.
+- [ ] Initial libvirt event mapping implemented.
+- [ ] Internal domain termination event cache preserves normalized reasons across
+      low-signal terminal notifications.
+- [ ] Internal domain termination event cache is cleared on domain start.
+- [ ] Kubernetes event emitted for observed termination states.
+- [ ] Prometheus metric emitted for observed termination states.
+- [ ] Unit tests cover all supported normalized reasons.
+- [ ] Functional tests cover guest shutdown, platform shutdown, and guest crash
+      where supported by the test environment.
+
+### Beta
+
+- [ ] TBD
+
+### GA
+
+- [ ] TBD

--- a/veps/sig-compute/362-guest-termination-state/vep.md
+++ b/veps/sig-compute/362-guest-termination-state/vep.md
@@ -1,4 +1,4 @@
-# VEP #362: Guest Termination State
+# VEP #362: Guest Termination Condition
 
 ## VEP Status Metadata
 
@@ -19,89 +19,81 @@ Items marked with (R) are required *prior to targeting to a milestone / release*
 
 ## Overview
 
-KubeVirt can observe several different ways in which a guest or its domain stops:
-shutdown initiated from inside the guest, KubeVirt/API requested shutdown,
-hypervisor-side stop, and guest crash/panic. Today these cases are mostly
-reflected through generic VMI phase and readiness condition, while other stop paths
-may surface as generic failure, pod termination, or Kubernetes events.
+KubeVirt tells users whether a VMI is running, stopped, or failed, but it does
+not retain the reason why the guest terminated. Some of that information exists
+briefly as a hypervisor lifecycle event in virt-launcher. It is lost once the
+launcher pod and VMI are gone.
 
-This proposal introduces a normalized guest termination state in the KubeVirt API.
-The state records the observed reason, message, and timestamp for a terminated
-guest/domain lifecycle. A VM-level copy also records the source VMI UID so the
-reason remains meaningful after the VMI object is deleted or replaced. It is
-intended as a durable, machine-readable source of truth for users and
-higher-level controllers that need to understand why a VM stopped.
+This VEP adds a `GuestTerminated` condition to the VMI and mirrors it to the VM.
+The condition is `False` while the guest is active and `True` after KubeVirt
+observes a supported termination reason. If the domain is no longer active but
+the reason is unavailable, the condition is `Unknown` instead of guessing.
+
+The reason uses KubeVirt terminology rather than exposing libvirt event names.
+This keeps the API useful if the hypervisor implementation changes later.
 
 ## Motivation
 
-Users and automation often need to distinguish expected guest behavior from
-infrastructure or platform behavior. Examples:
+There are practical differences between a guest running `shutdown now`, a guest
+kernel panic, an unexpected QEMU stop, and a shutdown requested by KubeVirt.
+Today those cases tend to converge on the same broad VMI phases and readiness
+states.
 
-- A user runs `shutdown now` inside the guest and expects to understand that the
-  VM stopped because the guest requested it.
-- A user or controller requests a VM stop through KubeVirt and expects that stop
-  to be distinguishable from a shutdown initiated inside the guest.
-- A guest kernel panic should be observable as a guest crash instead of being
-  conflated with ordinary shutdown.
-- Higher-level platforms built on KubeVirt need a stable status surface to decide
-  whether to recover, report, alert, bill, or leave an instance stopped.
+`Ready=False` answers whether the VMI is available. It does not answer why it
+stopped. `GuestNotRunning`, for example, is also used while a guest is starting.
+`RunStrategy` and `rebootPolicy` decide what KubeVirt should do next; neither is
+a record of what happened.
 
-Prior discussions and features address adjacent behavior but not a structured
-termination reason API:
+Kubernetes events are useful for notification and investigation, but they are
+not enough as the only API. They expire, may be aggregated, and require a
+consumer to watch and correlate a separate stream. A condition gives users and
+controllers a value they can query directly. Mirroring it to the VM keeps the
+answer available after the terminated VMI has been deleted.
 
-- Guest shutdown behavior and RunStrategy decide what KubeVirt should do after a
-  guest stops, but not why the guest stopped.
-- `rebootPolicy` makes guest reboot visible to KubeVirt when requested, but does
-  not expose the reason for a terminated guest/domain lifecycle.
-- Guest panic support emits Kubernetes events ([#16666](https://github.com/kubevirt/kubevirt/pull/16666))
-  and metrics ([#17836](https://github.com/kubevirt/kubevirt/pull/17836)) for one crash class,
-  but there is no general termination state covering shutdown and stop causes.
+This information can be used by higher-level platforms for recovery policy,
+user-facing stop reasons, alerting, and other lifecycle decisions that are not
+owned by KubeVirt's `RunStrategy`.
 
 ## Goals
 
-- Add a normalized guest/domain termination state to VMI status.
-- Add a VM-level last termination state copied from the latest relevant VMI so
-  the reason remains visible after the VMI is deleted.
-- Distinguish at least:
-  - guest-initiated shutdown
-  - KubeVirt/API requested shutdown
-  - host/hypervisor requested shutdown
-  - host/hypervisor observed unexpected stop/failure
-  - guest crash/panic
-- Emit a Kubernetes event when a guest termination state is observed.
-- Expose metrics for observed guest termination reasons.
+- Report whether the guest represented by a VMI has terminated.
+- Give a terminated guest a normalized, machine-readable reason when KubeVirt
+  observed one.
+- Keep the latest condition on the owning VM after the VMI is deleted.
+- Reset stale termination state when a new guest or replacement VMI starts.
+- Preserve a useful termination reason across later hypervisor events that no
+  longer carry it.
+- Emit Kubernetes events and metrics for supported termination reasons.
+- Keep the public API independent of libvirt.
 
 ## Non Goals
 
-- This proposal does not change RunStrategy semantics.
-- This proposal does not change `rebootPolicy` semantics.
-- This proposal does not introduce a recovery policy or automatic restart policy.
-- This proposal does not make `Ready` condition carry historical termination state.
-- This proposal does not guarantee attribution for node crashes where the
-  virt-launcher process and hypervisor event stream are lost before an event can
-  be observed.
+- Change `RunStrategy`, `rebootPolicy`, or their restart behavior.
+- Add a recovery policy to KubeVirt.
+- Make `Ready` carry termination history.
+- Diagnose application-level failures inside a running guest.
+- Attribute node loss when virt-launcher and its hypervisor event stream are
+  lost before they can report an outcome.
+- Claim cryptographic or transactional proof of which actor caused the final
+  ACPI poweroff.
 
 ## Definition of Users
 
-- VM owners who need to understand why their VM stopped.
+- VM owners checking why their VM stopped.
 - Cluster administrators and SREs investigating VM lifecycle incidents.
-- Higher-level controllers and platforms built on KubeVirt.
-- Monitoring and UI systems that need a stable source of VM stop attribution.
-- KubeVirt developers debugging guest/domain lifecycle behavior.
+- Controllers and platforms built on top of KubeVirt.
+- Monitoring and UI systems presenting guest termination information.
 
 ## User Stories
 
-- As a VM owner, I want to see that my VM stopped because the guest OS requested
-  shutdown, so I can distinguish expected in-guest behavior from a failure.
-- As a cluster administrator, I want guest crashes to be distinguishable from
-  platform-requested shutdown, so alerts and dashboards can report the right
-  cause.
-- As a higher-level controller, I want a machine-readable stop reason after the
-  VMI has disappeared, so I can make recovery decisions based on the last VMI
-  lifecycle.
-- As a KubeVirt developer, I want a normalized status field instead of relying on
-  libvirt-specific lifecycle detail names, so the API can survive future
-  hypervisor implementation changes.
+- As a VM owner, I want to see that the guest OS requested shutdown so that I
+  do not mistake an expected stop for an infrastructure failure.
+- As an administrator, I want a guest crash to be distinguishable from an
+  orderly shutdown.
+- As a higher-level controller, I want to read the latest termination reason
+  from the VM after its VMI has disappeared.
+- As a KubeVirt developer, I want this contract expressed in KubeVirt terms so
+  that changing the hypervisor backend does not change the public API.
 
 ## Repos
 
@@ -109,210 +101,276 @@ kubevirt/kubevirt
 
 ## Design
 
-### API
+### Condition contract
 
-Introduce a VMI-scoped termination state:
+No new status structure is introduced. The existing VMI and VM condition types
+gain `GuestTerminated`:
 
 ```go
-type VirtualMachineInstanceTerminationState struct {
-    // Reason is a short, stable, machine-readable termination reason.
-    // +optional
-    Reason VirtualMachineInstanceTerminationReason `json:"reason,omitempty"`
-
-    // Message is a human-readable explanation of the observed termination.
-    // +optional
-    Message string `json:"message,omitempty"`
-
-    // Timestamp is the time at which KubeVirt observed the termination event.
-    // +optional
-    Timestamp metav1.Time `json:"timestamp,omitempty"`
-}
-
-type VirtualMachineInstanceTerminationReason string
-
 const (
-    VirtualMachineInstanceTerminationReasonGuestShutdown              VirtualMachineInstanceTerminationReason = "GuestShutdown"
-    VirtualMachineInstanceTerminationReasonPlatformRequestedShutdown  VirtualMachineInstanceTerminationReason = "PlatformRequestedShutdown"
-    VirtualMachineInstanceTerminationReasonHostShutdown               VirtualMachineInstanceTerminationReason = "HostShutdown"
-    VirtualMachineInstanceTerminationReasonHostStoppedFailed          VirtualMachineInstanceTerminationReason = "HostStoppedFailed"
-    VirtualMachineInstanceTerminationReasonGuestCrashed               VirtualMachineInstanceTerminationReason = "GuestCrashed"
+    VirtualMachineInstanceGuestTerminated VirtualMachineInstanceConditionType = "GuestTerminated"
+    VirtualMachineGuestTerminated         VirtualMachineConditionType         = "GuestTerminated"
 )
 ```
 
-Add it to VMI status:
+For a VMI, the condition has the following meaning:
 
-```go
-type VirtualMachineInstanceStatus struct {
-    // TerminationState reports the observed termination state for this VMI
-    // lifecycle.
-    // +optional
-    TerminationState *VirtualMachineInstanceTerminationState `json:"terminationState,omitempty"`
-}
-```
+| Status | Meaning |
+|--------|---------|
+| `False` | The current guest incarnation has not terminated. |
+| `True` | The current guest incarnation has terminated and KubeVirt observed a supported reason. |
+| `Unknown` | The domain is no longer active, but KubeVirt could not determine a supported termination reason. |
 
-Add a VM-level copy that includes the VMI UID:
+`GuestTerminated=True` is not an event pulse. It remains true for the terminal
+remainder of that VMI's current guest incarnation. Starting a new incarnation
+resets it to `False`.
 
-```go
-type VirtualMachineTerminationState struct {
-    // VMIUID identifies the VMI lifecycle this termination state came from.
-    // +optional
-    VMIUID types.UID `json:"vmiUID,omitempty"`
+Before KubeVirt has observed an active domain, the condition may be absent.
+When the feature is disabled, the condition is removed.
 
-    // Reason is a short, stable, machine-readable termination reason.
-    // +optional
-    Reason VirtualMachineInstanceTerminationReason `json:"reason,omitempty"`
+Standard condition timestamps are used. Both timestamps are set when the
+condition is created or its status or reason changes. Reconciliation leaves the
+condition untouched while status and reason remain the same. There is no
+second, custom termination timestamp.
 
-    // Message is a human-readable explanation of the observed termination.
-    // +optional
-    Message string `json:"message,omitempty"`
+### Reasons
 
-    // Timestamp is the time at which KubeVirt observed the termination event.
-    // +optional
-    Timestamp metav1.Time `json:"timestamp,omitempty"`
-}
+When the condition is `False`, it uses:
 
-type VirtualMachineStatus struct {
-    // LastTerminationState reports the latest observed termination state copied
-    // from a VMI owned by this VM.
-    // +optional
-    LastTerminationState *VirtualMachineTerminationState `json:"lastTerminationState,omitempty"`
-}
-```
+| Reason | Message |
+|--------|---------|
+| `GuestNotTerminated` | `Guest has not terminated` |
 
-The VMI field is the authoritative state for a specific VMI lifecycle. The VM
-field is a durable copy for user-facing inspection after the VMI is deleted. The
-`vmiUID` field prevents consumers from accidentally treating a previous VMI
-lifecycle as the current one.
+When the condition is `True`, it uses one of these normalized reasons:
 
-### Reason semantics
+| Reason | Message | Meaning |
+|--------|---------|---------|
+| `GuestShutdown` | `Guest requested shutdown of the virtual machine` | The hypervisor reported a guest-completed shutdown and KubeVirt had no pending platform termination intent. |
+| `PlatformRequestedShutdown` | `Platform requested shutdown of the virtual machine` | KubeVirt had already requested termination when the shutdown was observed. |
+| `HostShutdown` | `Host requested shutdown of the virtual machine` | The hypervisor reported a host-side shutdown without a matching KubeVirt termination intent. |
+| `HostStoppedFailed` | `Host observed the virtual machine stop unexpectedly` | The hypervisor reported that the domain stopped unexpectedly or failed. |
+| `GuestCrashed` | `Guest crashed` | KubeVirt observed a guest panic or crash that ended the guest incarnation. |
 
-`GuestShutdown` means the guest OS requested shutdown/poweroff and KubeVirt
-observed a normal guest termination.
+When the condition is `Unknown`, it uses `TerminationReasonUnknown` with the
+message `Guest termination reason is unknown`.
 
-`PlatformRequestedShutdown` means KubeVirt requested domain shutdown as part of
-VM/VMI stop or deletion flow and the observed termination corresponds to that
-request.
+The values above are KubeVirt API values. They are not a promise to expose a
+particular libvirt detail indefinitely.
 
-`HostShutdown` means the hypervisor host side requested shutdown or destroy, but
-KubeVirt did not associate the event with a tracked platform shutdown request.
+### Observing termination
 
-`HostStoppedFailed` means the hypervisor reported that the domain stopped
-unexpectedly or failed without a more specific guest crash signal.
+virt-launcher is the first KubeVirt component that sees hypervisor lifecycle
+events. It normalizes supported events into an internal termination event and
+passes that information through the domain notification to virt-handler.
+virt-handler owns VMI status and updates the public condition.
 
-`GuestCrashed` means the guest reported or triggered a crash/panic signal.
+The initial libvirt backend uses this mapping:
 
-The exact names are open to SIG review. The important contract is that the
-reason values are normalized KubeVirt concepts, not libvirt event names.
-
-### Event collection
-
-The initial implementation can derive the normalized state from the existing
-virt-launcher to virt-handler domain status flow.
-
-virt-launcher records normalized termination events in the internal domain status
-sent to virt-handler. This internal value is not the public API. It is a
-transport detail used so virt-handler can update the VMI/VM API, emit events, and
-increment metrics.
-
-Current libvirt mapping:
-
-| Libvirt event | Libvirt detail | Normalized reason |
-|---------------|----------------|-------------------|
-| `DOMAIN_EVENT_SHUTDOWN` | `DOMAIN_EVENT_SHUTDOWN_GUEST` | `GuestShutdown`, unless matched to a pending KubeVirt shutdown intent |
-| `DOMAIN_EVENT_SHUTDOWN` | `DOMAIN_EVENT_SHUTDOWN_HOST` | `HostShutdown`, unless matched to a pending KubeVirt shutdown intent |
+| Libvirt event | Libvirt detail | Candidate reason |
+|---------------|----------------|------------------|
+| `DOMAIN_EVENT_SHUTDOWN` | `DOMAIN_EVENT_SHUTDOWN_GUEST` | `GuestShutdown`, or `PlatformRequestedShutdown` when platform intent takes precedence |
+| `DOMAIN_EVENT_SHUTDOWN` | `DOMAIN_EVENT_SHUTDOWN_HOST` | `HostShutdown`, or `PlatformRequestedShutdown` when platform intent takes precedence |
 | `DOMAIN_EVENT_CRASHED` | `DOMAIN_EVENT_CRASHED_PANICKED` | `GuestCrashed` |
-| `DOMAIN_EVENT_CRASHED` | `DOMAIN_EVENT_CRASHED_CRASHLOADED` | `GuestCrashed` |
+| `DOMAIN_EVENT_CRASHED` | `DOMAIN_EVENT_CRASHED_CRASHLOADED` | records a guest crash signal, but does not by itself prove that the guest incarnation has terminated |
 | `DOMAIN_EVENT_STOPPED` | `DOMAIN_EVENT_STOPPED_CRASHED` | `GuestCrashed` |
 | `DOMAIN_EVENT_STOPPED` | `DOMAIN_EVENT_STOPPED_FAILED` | `HostStoppedFailed` |
 | `DOMAIN_EVENT_STOPPED` | `DOMAIN_EVENT_STOPPED_DESTROYED` | no new reason |
 | `DOMAIN_EVENT_STOPPED` | `DOMAIN_EVENT_STOPPED_SHUTDOWN` | no new reason |
 | `DOMAIN_EVENT_STOPPED` | `DOMAIN_EVENT_STOPPED_MIGRATED` | no new reason |
 
-`DOMAIN_EVENT_STOPPED_CRASHED` may refine or overwrite a preceding
-`DOMAIN_EVENT_CRASHED_*` event because it confirms that the domain has stopped.
+The condition becomes `True` only when the observed lifecycle state means that
+the guest incarnation has ended. An early crash signal may be retained as the
+candidate reason until a terminal state is observed. This is especially
+important for `CRASHED_CRASHLOADED`, where a crash kernel can still be running.
 
-`PlatformRequestedShutdown` is detected by recording a pending KubeVirt shutdown
-intent when virt-launcher issues the shutdown request on behalf of KubeVirt. The
-intent is consumed by the next matching shutdown event. The intent is considered
-fresh for the larger of a default freshness window and the VMI termination grace
-period plus a small margin. A stale intent is cleared and ignored.
+Some useful events are followed by events with less information. A normal guest
+shutdown, for example, commonly produces `SHUTDOWN_GUEST` followed by
+`STOPPED_SHUTDOWN`. A panic can produce `CRASHED_PANICKED` followed by
+`STOPPED_CRASHED`. The later event must not erase the reason already observed.
 
-### Sticky internal domain termination event
+### Platform termination intent
 
-Some domain lifecycles produce a useful first event followed by a later terminal
-event that does not carry enough information by itself. For example:
+An ACPI shutdown requested by KubeVirt and a genuine `shutdown now` converge on
+the same final operation: the guest writes ACPI S5 and QEMU reports a guest
+shutdown. The final event does not contain a request identifier, so exact
+causality cannot be recovered from that event alone.
 
-- guest shutdown: `SHUTDOWN_GUEST` followed by `STOPPED_SHUTDOWN`
-- platform-requested shutdown: `SHUTDOWN_GUEST` or `SHUTDOWN_HOST` matched to a
-  pending platform intent, followed by `STOPPED_SHUTDOWN` or `STOPPED_DESTROYED`
-- guest crash: `CRASHED_PANICKED` followed by `STOPPED_CRASHED`
+KubeVirt records a pending platform termination intent immediately before
+`SignalShutdownVMI` asks libvirt to send the ACPI power-button request. The
+intent is scoped to the current domain incarnation and consumed by the first
+matching shutdown event. It is cleared when the request fails, a new domain
+incarnation starts, or the intent expires.
 
-To avoid losing the useful reason during the final domain notification,
-virt-launcher keeps the last observed normalized termination event in its
-per-launcher metadata cache. When a later domain notification does not map to a
-new normalized reason, virt-launcher attaches the cached event to the domain
-status sent to virt-handler.
+The freshness period is the larger of two minutes and the VMI termination grace
+period plus 30 seconds. The longer value allows guests with a long graceful
+shutdown period to finish without losing the platform intent.
 
-The cached event is scoped to one virt-launcher/domain lifecycle. It is cleared
-when a `DOMAIN_EVENT_STARTED` event is observed. The same start event also clears
-any pending platform termination intent. This prevents a termination reason from
-leaking into a fresh domain incarnation.
+While an intent is pending, `PlatformRequestedShutdown` deliberately takes
+precedence over `GuestShutdown` or `HostShutdown`. Reaching
+`SignalShutdownVMI` means KubeVirt has already committed to terminating that
+VMI. In the usual deletion path the VMI has a `deletionTimestamp`, and that
+deletion cannot be cancelled. If the guest independently starts shutting down
+at the same time, the controlling lifecycle operation is still the KubeVirt
+termination.
 
-If a low-signal terminal event is observed without any cached normalized event,
-KubeVirt does not infer a termination reason from it. This avoids turning
-ambiguous terminal states into misleading user-visible attribution.
+This reason means "KubeVirt had requested termination when shutdown was
+observed." It does not claim that KubeVirt can prove its ACPI request caused the
+guest's final S5 write. Obtaining that proof would require a request token to be
+carried through the guest and returned with the final shutdown signal.
 
-### VM propagation
+### Reliable delivery and lifecycle scope
 
-When a VMI owned by a VM has `status.terminationState`, virt-controller copies it
-to `vm.status.lastTerminationState` with the source VMI UID.
+The condition is meant to survive the transient source event, so a supported
+termination event cannot exist only in the bounded, best-effort libvirt event
+queue.
 
-The VM field is intentionally named `lastTerminationState` because it is
-historical. It is not a statement that the current VMI, if one exists, is
-terminated.
+virt-launcher latches termination-classifying lifecycle data in synchronized
+per-launcher state before attempting to enqueue the generic notification. It
+then signals the notification loop independently. Queue saturation may coalesce
+notifications, but it must not discard the retained termination reason.
+
+The retained data belongs to one guest incarnation. A libvirt
+`DOMAIN_EVENT_STARTED` clears it as a fast path. Reconciliation also compares
+the active runtime identity with the identity stored alongside the retained
+event. If the identity changed, the old event is cleared even if the `STARTED`
+callback was dropped.
+
+Later low-signal events from the same incarnation keep the retained reason. If
+the domain reaches a terminal state and no reason was retained, virt-handler
+sets `GuestTerminated=Unknown` rather than leaving a stale `False` condition or
+inventing a reason.
+
+### VMI condition update
+
+virt-handler derives the condition from the latest domain observation:
+
+1. A supported terminal reason produces `GuestTerminated=True`.
+2. An active domain produces `GuestTerminated=False`.
+3. A terminal domain without a supported reason produces
+   `GuestTerminated=Unknown`.
+4. A later low-signal update from the same incarnation does not erase an
+   already recorded reason.
+
+The normal KubeVirt condition manager performs the update. It leaves an existing
+condition untouched while status and reason remain the same.
+
+When the feature is enabled, the reconciliation that moves a VMI to a final
+phase must also leave it with `GuestTerminated=True` or
+`GuestTerminated=Unknown`. Updating this condition must not be skipped only
+because the VMI has already entered a final phase. Other final VMI status is not
+recomputed in that path.
+
+### VM condition synchronization
+
+The owning VM mirrors the VMI's `GuestTerminated` condition. The VM copy has a
+specific synchronization path rather than relying only on the generic
+condition-copy loop:
+
+- While a VMI exists and carries the condition, copy it to the VM.
+- If a replacement VMI exists but does not yet carry the condition, remove the
+  previous VM condition. This prevents a reason from the old VMI from looking
+  current.
+- Once the VMI is gone, retain the condition last copied from it.
+- A new VMI's `False`, `True`, or `Unknown` condition replaces the retained
+  value normally.
+
+VM-owned VMIs already carry `VirtualMachineControllerFinalizer`.
+virt-controller updates VM status before removing that finalizer. If the VM
+status update fails, the finalizer remains and the copy is retried. Therefore a
+VMI carrying `GuestTerminated` cannot disappear before virt-controller has had
+the opportunity to persist it on the VM.
+
+For a stopped VM without a VMI, `GuestTerminated=True` describes the latest
+guest that belonged to that VM. It stops being current as soon as a replacement
+VMI appears, at which point the dedicated synchronization above removes or
+replaces it.
 
 ### Kubernetes events
 
-When KubeVirt observes a normalized termination state, it emits a Kubernetes
-event on the VMI:
+When the VMI condition first becomes `True`, or its normalized reason changes,
+virt-handler emits a Kubernetes event on the VMI.
 
-- Event type `Normal` for expected shutdown reasons.
-- Event type `Warning` for crash or unexpected stop reasons.
-- Event reason is the normalized termination reason.
-- Event message is the same human-readable message used in status.
+- Expected shutdown reasons use event type `Normal`.
+- Guest crashes and unexpected host-side stops use event type `Warning`.
+- The event reason matches the normalized condition reason.
+- The message is the same human-readable text used by the condition.
+
+Events remain complementary observability. Consumers that need current state
+should read the condition.
 
 ### Metrics
 
-Expose a counter for observed guest termination states:
+virt-handler exposes:
 
 ```text
 kubevirt_vmi_guest_os_termination_total{namespace, name, reason}
 ```
 
-The metric follows the precedent of guest panic metrics and allows operators to
-track fleet-wide termination causes. Implementations should avoid adding
-high-cardinality detail labels such as raw hypervisor messages.
+The counter increments when `GuestTerminated` first becomes `True` or changes to
+a different supported termination reason. Per-VMI label sets are removed during
+final VMI cleanup so the virt-handler process does not retain them indefinitely.
+No raw hypervisor messages or other unbounded details are used as labels.
+
+### Feature gate
+
+The initial implementation is guarded by the Alpha `GuestTermination` feature
+gate. When disabled, KubeVirt does not publish the VMI or VM condition and does
+not emit the termination event or metric.
+
+Internal observation may still take place because it belongs to the existing
+virt-launcher domain event path, but it has no user-visible effect while the
+gate is disabled.
 
 ## API Examples
 
-Guest shutdown visible on the VMI:
+An active guest:
 
 ```yaml
-apiVersion: kubevirt.io/v1
-kind: VirtualMachineInstance
-metadata:
-  name: fedora
-  namespace: default
-  uid: 7d5f0d4d-3df8-442f-bd64-9ee9d0f6fb8e
 status:
-  phase: Succeeded
-  terminationState:
-    reason: GuestShutdown
-    message: Guest requested shutdown of the virtual machine
-    timestamp: "2026-06-15T12:00:00Z"
+  conditions:
+  - type: GuestTerminated
+    status: "False"
+    reason: GuestNotTerminated
+    message: Guest has not terminated
 ```
 
-The same reason copied to the VM after the VMI is gone:
+A guest that ran `shutdown now`:
+
+```yaml
+status:
+  phase: Succeeded
+  conditions:
+  - type: GuestTerminated
+    status: "True"
+    reason: GuestShutdown
+    message: Guest requested shutdown of the virtual machine
+    lastProbeTime: "2026-09-04T12:00:00Z"
+    lastTransitionTime: "2026-09-04T12:00:00Z"
+```
+
+A shutdown observed while KubeVirt was terminating the VMI:
+
+```yaml
+status:
+  conditions:
+  - type: GuestTerminated
+    status: "True"
+    reason: PlatformRequestedShutdown
+    message: Platform requested shutdown of the virtual machine
+```
+
+A domain that is terminal without a supported reason:
+
+```yaml
+status:
+  conditions:
+  - type: GuestTerminated
+    status: "Unknown"
+    reason: TerminationReasonUnknown
+    message: Guest termination reason is unknown
+```
+
+After the VMI is deleted, the owning VM retains the latest condition:
 
 ```yaml
 apiVersion: kubevirt.io/v1
@@ -322,118 +380,165 @@ metadata:
   namespace: default
 status:
   printableStatus: Stopped
-  lastTerminationState:
-    vmiUID: 7d5f0d4d-3df8-442f-bd64-9ee9d0f6fb8e
+  conditions:
+  - type: GuestTerminated
+    status: "True"
     reason: GuestShutdown
     message: Guest requested shutdown of the virtual machine
-    timestamp: "2026-06-15T12:00:00Z"
-```
-
-Guest crash:
-
-```yaml
-status:
-  terminationState:
-    reason: GuestCrashed
-    message: Guest crashed
-    timestamp: "2026-06-15T12:05:00Z"
-```
-
-Platform requested shutdown:
-
-```yaml
-status:
-  terminationState:
-    reason: PlatformRequestedShutdown
-    message: Platform requested shutdown of the virtual machine
-    timestamp: "2026-06-15T12:10:00Z"
 ```
 
 ## Alternatives
 
-### Use the Ready condition
+### Use only `Ready` and VMI phase
 
-`Ready` already reports `GuestNotRunning`, `PodTerminating`, and other
-availability states. It is not a good fit for termination attribution because it
-is transient, availability-oriented, and can copy pod readiness reasons directly.
-`GuestNotRunning` also covers startup and other non-running windows, not only
-guest termination.
+`Ready` and phase describe broad availability and lifecycle outcomes. They do
+not distinguish an orderly guest shutdown from a guest crash or unexpected
+host-side stop. Extending `Ready` with this history would also mix availability
+with termination attribution.
 
-### Add a GuestTerminated condition
+### Use only Kubernetes events
 
-A condition is useful for current state, but less suitable for durable historical
-state. It also creates awkward behavior across VM restarts: a `True` condition can
-look current even when it describes a previous VMI lifecycle. A structured status
-field with source `vmiUID` is clearer for "last observed termination".
+The source information is event-like, but the use case is not only audit. A
+controller may need the latest reason after it starts, reconnects, or observes a
+VM whose VMI has already disappeared. Kubernetes events are retained for a
+limited time and are not a suitable state API.
 
-### Use only Kubernetes events or metrics
+### Add dedicated termination fields to VMI and VM status
 
-Events and metrics are useful for observability, but they are not a stable API
-source of truth for controllers. Events can expire and metrics are eventually
-scraped. Status is the right API surface for current and last observed state.
+An earlier version of this VEP proposed `terminationState` on the VMI and
+`lastTerminationState` on the VM. That gives stronger typing and can include the
+source VMI UID directly, but it introduces a separate status structure for a
+small finite state that fits the standard condition model.
+
+The condition is valid as current state when its lifecycle is defined clearly:
+it is `False` for the active incarnation, `True` for its terminal remainder,
+and reset when a new incarnation or replacement VMI starts.
+
+### Add a separate platform-termination condition
+
+Another option is to report guest termination and platform termination intent
+as two independent conditions. That avoids combining observed shutdown with
+intent, but leaves every consumer to perform the same correlation and adds
+another condition to VM status.
+
+The proposed design keeps one condition and defines platform intent precedence
+inside KubeVirt. Its limitation is documented rather than presented as exact
+physical causality.
+
+### Add or extend a poweroff policy
+
+A poweroff policy could decide whether a guest poweroff stops or restarts the
+domain. It would not by itself expose why the poweroff happened. It also cannot
+distinguish a genuine in-guest shutdown from an ACPI shutdown requested by
+KubeVirt because both end with the guest writing ACPI S5.
+
+### Require exact causal attribution from the hypervisor
+
+Libvirt can remember that its shutdown API was called, but it faces the same
+correlation problem as KubeVirt: QEMU later reports only that the guest completed
+shutdown. Exact attribution would require a token propagated through the guest,
+which is not available in the current ACPI shutdown protocol.
 
 ## Scalability
 
-The status fields are small and updated only when KubeVirt observes a guest/domain
-termination event. The metric adds one counter series per observed VMI and reason,
-matching existing KubeVirt per-VMI metric patterns. Implementations should avoid
-labels derived from raw messages, domain names, or crash payloads.
+Each VMI and VM gains at most one condition. Condition updates occur only when
+the state or reason changes.
+
+virt-launcher retains one small termination record for the current domain
+incarnation. The Prometheus counter uses one series per observed VMI and reason,
+following existing per-VMI metric patterns, and removes those label sets during
+VMI cleanup.
 
 ## Update/Rollback Compatibility
 
-This is an additive status API and is backward compatible.
+This is an additive condition type and is backward compatible. Older clients
+ignore condition types they do not recognize. Consumers must treat the
+condition as optional because it may be absent before the domain is observed,
+while the feature is disabled, or during a mixed-version rollout.
 
-During upgrade, new KubeVirt components begin populating the optional status
-fields when the feature gate is enabled. Older clients ignore the new fields.
-
-During rollback, older KubeVirt components stop updating the fields. Existing
-status values may remain until the object is updated or recreated. Consumers must
-treat the fields as optional.
-
-The initial implementation should be guarded by a feature gate, tentatively named
-`GuestTermination`.
+After rollback or disabling the gate, controllers stop publishing the condition
+and remove it when they next reconcile the affected objects. A value can remain
+temporarily on an object that is no longer being reconciled, which is why clients
+must not assume the condition is always present.
 
 ## Functional Testing Approach
 
-- Unit test mapping from hypervisor lifecycle events to normalized termination
-  reasons.
-- Unit test pending KubeVirt shutdown intent matching and stale intent cleanup.
-- Unit test that later low-signal domain notifications preserve the cached
-  normalized termination event.
-- Unit test that domain start clears stale in-launcher termination state and
-  pending platform termination intent.
-- Unit test VMI status updates for each normalized reason.
-- Unit test VM propagation from VMI `terminationState` to VM
-  `lastTerminationState`.
-- Functional test guest-initiated shutdown from inside a Linux guest.
-- Functional test KubeVirt/API requested VM stop or VMI deletion.
-- Functional test guest panic when panic devices are available.
-- Functional test unexpected hypervisor stop/failure path where practical.
-- Verify no status, event, or metric is emitted when the feature gate is disabled.
+Unit coverage will verify:
+
+- Mapping supported hypervisor lifecycle events to normalized reasons.
+- `False`, `True`, and `Unknown` VMI condition transitions.
+- A terminal VMI receives `True` or `Unknown` before its finalizers can be
+  removed, including when the classifying event arrives late.
+- Platform intent precedence, expiry, consumption, and cleanup on start.
+- A crash while platform intent is pending does not misclassify the next
+  incarnation.
+- Low-signal terminal events preserve a previously observed reason.
+- Termination state is retained before the best-effort event queue and survives
+  queue saturation.
+- A changed runtime incarnation clears stale state even when the `STARTED`
+  callback is missed.
+- VM status is updated before the VM controller finalizer is removed from the
+  terminated VMI.
+- A replacement VMI removes or replaces the previous VM condition.
+- Metrics increment once per condition transition and are cleaned up with the
+  VMI.
+- Disabling the feature gate removes all user-visible behavior.
+
+Functional tests will cover:
+
+- `shutdown now` inside a Linux guest.
+- VMI deletion and graceful platform-requested shutdown.
+- Guest kernel panic when the test environment supports a panic device.
+- Unexpected QEMU termination.
+- VMI deletion followed by creation of a replacement VMI, verifying that the VM
+  condition does not retain the old reason.
+
+Node loss is tested as an unclassified outcome where no hypervisor event can be
+delivered.
 
 ## Implementation History
+
+- 2026-08-26: Draft implementation opened in
+  [kubevirt/kubevirt#18948](https://github.com/kubevirt/kubevirt/pull/18948).
+- 2026-09-04: VEP revised around the `GuestTerminated` condition contract and
+  lifecycle-scoped event retention.
 
 ## Graduation Requirements
 
 ### Alpha
 
-- [ ] Feature gate added.
-- [ ] VMI `status.terminationState` API added.
-- [ ] VM `status.lastTerminationState` API added.
-- [ ] Initial libvirt event mapping implemented.
-- [ ] Internal domain termination event cache preserves normalized reasons across
-      low-signal terminal notifications.
-- [ ] Internal domain termination event cache is cleared on domain start.
-- [ ] Kubernetes event emitted for observed termination states.
-- [ ] Prometheus metric emitted for observed termination states.
-- [ ] Unit tests cover all supported normalized reasons.
-- [ ] Functional tests cover guest shutdown, platform shutdown, and guest crash
-      where supported by the test environment.
+- [ ] `GuestTermination` feature gate added.
+- [ ] VMI and VM `GuestTerminated` condition types added.
+- [ ] Initial normalized reason set implemented.
+- [ ] Termination-classifying events retained before any best-effort queue.
+- [ ] Retained state scoped to a domain incarnation with a reconciliation
+      fallback when `STARTED` is missed.
+- [ ] Dedicated VM synchronization preserves the terminal condition after VMI
+      deletion and clears it for a replacement VMI.
+- [ ] Kubernetes events and Prometheus metrics implemented.
+- [ ] Unit and functional tests cover the supported paths and lifecycle reset.
 
 ### Beta
 
-- [ ] TBD
+- [ ] Reason semantics and platform-intent precedence have remained stable for
+      at least one release.
+- [ ] Upgrade and rollback coverage includes mixed virt-launcher, virt-handler,
+      and virt-controller versions.
+- [ ] Operational feedback shows no unresolved stale-condition or silent event
+      loss cases.
+- [ ] User documentation describes condition semantics and known attribution
+      limits.
+
+#### On-By-Default Readiness
+
+- [ ] The condition does not change existing VM restart behavior.
+- [ ] Metrics and condition updates have acceptable control-plane and
+      monitoring overhead at scale.
+- [ ] Consumers can safely handle `Unknown` and condition absence.
 
 ### GA
 
-- [ ] TBD
+- [ ] The normalized reason set and lifecycle contract are considered stable.
+- [ ] No known condition-retention issue can leak a previous VMI or domain
+      incarnation into the current VM state.
+- [ ] The feature gate is removed according to the KubeVirt feature lifecycle.

--- a/veps/sig-compute/362-guest-termination-state/vep.md
+++ b/veps/sig-compute/362-guest-termination-state/vep.md
@@ -22,10 +22,8 @@ Items marked with (R) are required *prior to targeting to a milestone / release*
 KubeVirt can observe several different ways in which a guest or its domain stops:
 shutdown initiated from inside the guest, KubeVirt/API requested shutdown,
 hypervisor-side stop, and guest crash/panic. Today these cases are mostly
-reflected through generic VMI phase and readiness condition. For example, a guest
-shutdown can eventually appear as `phase: Succeeded` with
-`Ready=False, reason=GuestNotRunning`, while other stop paths may surface as
-generic failure, pod termination, or Kubernetes events.
+reflected through generic VMI phase and readiness condition, while other stop paths
+may surface as generic failure, pod termination, or Kubernetes events.
 
 This proposal introduces a normalized guest termination state in the KubeVirt API.
 The state records the observed reason, message, and timestamp for a terminated
@@ -33,9 +31,6 @@ guest/domain lifecycle. A VM-level copy also records the source VMI UID so the
 reason remains meaningful after the VMI object is deleted or replaced. It is
 intended as a durable, machine-readable source of truth for users and
 higher-level controllers that need to understand why a VM stopped.
-
-The public API is hypervisor-agnostic. Current libvirt lifecycle events are used
-only as one implementation source for populating the normalized reasons.
 
 ## Motivation
 
@@ -73,12 +68,8 @@ termination reason API:
   - host/hypervisor requested shutdown
   - host/hypervisor observed unexpected stop/failure
   - guest crash/panic
-- Keep the public API independent from libvirt event names.
-- Preserve an observed termination reason across later low-signal terminal
-  domain notifications in the same domain lifecycle.
 - Emit a Kubernetes event when a guest termination state is observed.
 - Expose metrics for observed guest termination reasons.
-- Guard the initial implementation behind a feature gate.
 
 ## Non Goals
 
@@ -89,7 +80,6 @@ termination reason API:
 - This proposal does not guarantee attribution for node crashes where the
   virt-launcher process and hypervisor event stream are lost before an event can
   be observed.
-- This proposal does not expose libvirt event names as KubeVirt API values.
 
 ## Definition of Users
 
@@ -375,13 +365,6 @@ A condition is useful for current state, but less suitable for durable historica
 state. It also creates awkward behavior across VM restarts: a `True` condition can
 look current even when it describes a previous VMI lifecycle. A structured status
 field with source `vmiUID` is clearer for "last observed termination".
-
-### Store the reason only on the VM
-
-The VM is the best user-facing place after the VMI is deleted, but the VMI is the
-natural authoritative object for a specific domain lifecycle. Keeping both fields
-allows controllers to reason about the current VMI lifecycle while still
-preserving a durable VM-level copy.
 
 ### Use only Kubernetes events or metrics
 

--- a/veps/sig-compute/362-guest-termination-state/vep.md
+++ b/veps/sig-compute/362-guest-termination-state/vep.md
@@ -25,7 +25,7 @@ briefly as a hypervisor lifecycle event in virt-launcher. It is lost once the
 launcher pod and VMI are gone.
 
 This VEP adds a `GuestTerminated` condition to the VMI and mirrors it to the VM.
-The condition is `False` while the guest is active and `True` after KubeVirt
+The condition is absent while the guest is active and `True` after KubeVirt
 observes a supported termination reason. If the domain is no longer active but
 the reason is unavailable, the condition is `Unknown` instead of guessing.
 
@@ -56,11 +56,11 @@ owned by KubeVirt's `RunStrategy`.
 
 ## Goals
 
-- Report whether the guest represented by a VMI has terminated.
-- Give a terminated guest a normalized, machine-readable reason when KubeVirt
-  observed one.
-- Keep the latest condition on the owning VM after the VMI is deleted.
-- Reset stale termination state when a new guest or replacement VMI starts.
+- Report whether the guest represented by a VMI has terminated at some point,
+  with a normalized, machine-readable reason when KubeVirt observed one.
+- Preserve a queryable record of when and why the guest stopped, including
+  after its VMI is deleted, resetting stale termination state when a new guest
+  or replacement VMI starts.
 - Preserve a useful termination reason across later hypervisor events that no
   longer carry it.
 - Emit Kubernetes events and metrics for supported termination reasons.
@@ -117,16 +117,12 @@ For a VMI, the condition has the following meaning:
 
 | Status | Meaning |
 |--------|---------|
-| `False` | The current guest incarnation has not terminated. |
 | `True` | The current guest incarnation has terminated and KubeVirt observed a supported reason. |
-| `Unknown` | The domain is no longer active, but KubeVirt could not determine a supported termination reason. |
+| `Unknown` | KubeVirt observed that the current guest incarnation terminated, but no supported termination reason was available. |
 
 `GuestTerminated=True` is not an event pulse. It remains true for the terminal
 remainder of that VMI's current guest incarnation. Starting a new incarnation
-resets it to `False`.
-
-Before KubeVirt has observed an active domain, the condition may be absent.
-When the feature is disabled, the condition is removed.
+clears it from both the VMI and VM.
 
 Standard condition timestamps are used. Both timestamps are set when the
 condition is created or its status or reason changes. Reconciliation leaves the
@@ -135,11 +131,19 @@ second, custom termination timestamp.
 
 ### Reasons
 
-When the condition is `False`, it uses:
+Below are constants for all supported `GuestTerminated` reasons.
+The same constants cover both VMI and VM conditions because the condition is
+copied unchanged.
 
-| Reason | Message |
-|--------|---------|
-| `GuestNotTerminated` | `Guest has not terminated` |
+```go
+const (
+    GuestShutdownReason                  = "GuestShutdown"
+    PlatformRequestedShutdownReason      = "PlatformRequestedShutdown"
+    HostShutdownReason                   = "HostShutdown"
+    HostStoppedFailedReason              = "HostStoppedFailed"
+    GuestCrashedReason                   = "GuestCrashed"
+)
+```
 
 When the condition is `True`, it uses one of these normalized reasons:
 
@@ -229,23 +233,27 @@ per-launcher state before attempting to enqueue the generic notification. It
 then signals the notification loop independently. Queue saturation may coalesce
 notifications, but it must not discard the retained termination reason.
 
-The retained data belongs to one guest incarnation. A libvirt
-`DOMAIN_EVENT_STARTED` clears it as a fast path. Reconciliation also compares
-the active runtime identity with the identity stored alongside the retained
-event. If the identity changed, the old event is cleared even if the `STARTED`
-callback was dropped.
+The retained data is scoped to one virt-launcher process and its VMI. A
+replacement VMI runs in a new launcher process with a new cache and therefore
+cannot inherit the previous VMI's retained event.
+
+Within the same launcher process, a libvirt `DOMAIN_EVENT_STARTED` callback
+clears the retained event and any pending platform termination intent before
+the generic domain notification is enqueued. Queue saturation or notification
+coalescing therefore cannot lose this reset. This proposal does not add a
+separate runtime identity or a fallback for a `DOMAIN_EVENT_STARTED` callback
+that libvirt does not deliver.
 
 Later low-signal events from the same incarnation keep the retained reason. If
 the domain reaches a terminal state and no reason was retained, virt-handler
-sets `GuestTerminated=Unknown` rather than leaving a stale `False` condition or
-inventing a reason.
+sets `GuestTerminated=Unknown` rather than inventing a reason.
 
 ### VMI condition update
 
 virt-handler derives the condition from the latest domain observation:
 
 1. A supported terminal reason produces `GuestTerminated=True`.
-2. An active domain produces `GuestTerminated=False`.
+2. An active domain produces no condition.
 3. A terminal domain without a supported reason produces
    `GuestTerminated=Unknown`.
 4. A later low-signal update from the same incarnation does not erase an
@@ -271,14 +279,15 @@ condition-copy loop:
   previous VM condition. This prevents a reason from the old VMI from looking
   current.
 - Once the VMI is gone, retain the condition last copied from it.
-- A new VMI's `False`, `True`, or `Unknown` condition replaces the retained
+- A new VMI's `True`, or `Unknown` condition replaces the retained
   value normally.
 
 VM-owned VMIs already carry `VirtualMachineControllerFinalizer`.
 virt-controller updates VM status before removing that finalizer. If the VM
 status update fails, the finalizer remains and the copy is retried. Therefore a
 VMI carrying `GuestTerminated` cannot disappear before virt-controller has had
-the opportunity to persist it on the VM.
+the opportunity to persist it on the VM. However, virt-controller will need to
+ensure that virt-handler has added this condition before removing the finalizer.
 
 For a stopped VM without a VMI, `GuestTerminated=True` describes the latest
 guest that belonged to that VM. It stops being current as soon as a replacement
@@ -322,17 +331,6 @@ virt-launcher domain event path, but it has no user-visible effect while the
 gate is disabled.
 
 ## API Examples
-
-An active guest:
-
-```yaml
-status:
-  conditions:
-  - type: GuestTerminated
-    status: "False"
-    reason: GuestNotTerminated
-    message: Guest has not terminated
-```
 
 A guest that ran `shutdown now`:
 
@@ -411,8 +409,8 @@ source VMI UID directly, but it introduces a separate status structure for a
 small finite state that fits the standard condition model.
 
 The condition is valid as current state when its lifecycle is defined clearly:
-it is `False` for the active incarnation, `True` for its terminal remainder,
-and reset when a new incarnation or replacement VMI starts.
+it is absent for the active incarnation, `True` for its terminal remainder,
+and cleared when a new incarnation or replacement VMI starts.
 
 ### Add a separate platform-termination condition
 
@@ -451,22 +449,34 @@ VMI cleanup.
 
 ## Update/Rollback Compatibility
 
-This is an additive condition type and is backward compatible. Older clients
-ignore condition types they do not recognize. Consumers must treat the
-condition as optional because it may be absent before the domain is observed,
-while the feature is disabled, or during a mixed-version rollout.
+The new condition type is an additive API change and is backward compatible for
+condition consumers. Older clients ignore condition types they do not
+recognize. Consumers must treat `GuestTerminated` as optional because it may be
+absent while the feature is disabled or during a mixed-version rollout.
 
-After rollback or disabling the gate, controllers stop publishing the condition
-and remove it when they next reconcile the affected objects. A value can remain
-temporarily on an object that is no longer being reconciled, which is why clients
-must not assume the condition is always present.
+This does not guarantee that every older status writer preserves the condition.
+Mixed-version behavior for virt-launcher, virt-handler, and virt-controller will
+be covered before Beta.
+
+VMIs that continue using a pre-feature virt-launcher after an upgrade cannot
+report a normalized termination reason. A new virt-handler may report 
+`GuestTerminated=Unknown` if it observes the terminal domain state; otherwise,
+the condition remains absent. Classified reasons become available after the VMI
+is recreated with an upgraded virt-launcher.
+
+Disabling the feature gate while supporting controllers are running removes the
+condition when the affected objects are reconciled. Rolling back directly to
+binaries that do not know about the condition is different: an existing value
+may remain until the object is replaced, deleted, or reconciled again by a
+supporting version. Consumers must therefore not use the presence of the
+condition to determine whether the feature is currently enabled.
 
 ## Functional Testing Approach
 
 Unit coverage will verify:
 
 - Mapping supported hypervisor lifecycle events to normalized reasons.
-- `False`, `True`, and `Unknown` VMI condition transitions.
+- `True`, absent, and `Unknown` VMI condition transitions.
 - A terminal VMI receives `True` or `Unknown` before its finalizers can be
   removed, including when the classifying event arrives late.
 - Platform intent precedence, expiry, consumption, and cleanup on start.
@@ -475,8 +485,8 @@ Unit coverage will verify:
 - Low-signal terminal events preserve a previously observed reason.
 - Termination state is retained before the best-effort event queue and survives
   queue saturation.
-- A changed runtime incarnation clears stale state even when the `STARTED`
-  callback is missed.
+- A `DOMAIN_EVENT_STARTED` callback clears retained termination state before
+  notification delivery, including when the notification queue is saturated.
 - VM status is updated before the VM controller finalizer is removed from the
   terminated VMI.
 - A replacement VMI removes or replaces the previous VM condition.
@@ -511,11 +521,11 @@ delivered.
 - [ ] VMI and VM `GuestTerminated` condition types added.
 - [ ] Initial normalized reason set implemented.
 - [ ] Termination-classifying events retained before any best-effort queue.
-- [ ] Retained state scoped to a domain incarnation with a reconciliation
-      fallback when `STARTED` is missed.
+- [ ] Retained state scoped to a launcher process and cleared synchronously on
+      `DOMAIN_EVENT_STARTED`.
 - [ ] Dedicated VM synchronization preserves the terminal condition after VMI
       deletion and clears it for a replacement VMI.
-- [ ] Kubernetes events and Prometheus metrics implemented.
+- [ ] Kubernetes events implemented.
 - [ ] Unit and functional tests cover the supported paths and lifecycle reset.
 
 ### Beta
@@ -526,6 +536,7 @@ delivered.
       and virt-controller versions.
 - [ ] Operational feedback shows no unresolved stale-condition or silent event
       loss cases.
+- [ ] Prometheus metrics implemented.
 - [ ] User documentation describes condition semantics and known attribution
       limits.
 


### PR DESCRIPTION
### VEP Metadata

**Tracking issue**: https://github.com/kubevirt/enhancements/issues/362
**SIG label**: /sig compute

### What this PR does
Introducing VEP for surfacing guest termination state through VM/VMI status.

### Special notes for your reviewer
None. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a proposal for retaining guest termination status and reasons after the launcher pod or VMI is removed.
  * Documents supported termination reasons, lifecycle behavior, condition synchronization with the owning VM, and handling for replacement VMIs.
  * Defines related events, metrics, feature-gate behavior, API examples, compatibility considerations, and testing requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->