### PR TITLE
VEP 156: target GA for VMI memory overhead reporting

### DIFF
--- a/veps/sig-compute/156-vmi-memory-overhead-reporting/vmi-memory-overhead-reporting.md
+++ b/veps/sig-compute/156-vmi-memory-overhead-reporting/vmi-memory-overhead-reporting.md
@@ -6,7 +6,7 @@
 
 - This VEP targets alpha for version: v1.8
 - This VEP targets beta for version: v1.9
-- This VEP targets GA for version:
+- This VEP targets GA for version: v1.10
 
 ### Release Signoff Checklist
 
@@ -15,7 +15,7 @@ Items marked with (R) are required *prior to targeting to a milestone / release*
 - [X] (R) Enhancement issue created, which links to VEP dir in [kubevirt/enhancements].
 - [x] (R) Alpha target version is explicitly mentioned and approved
 - [ ] (R) Beta target version is explicitly mentioned and approved
-- [ ] (R) GA target version is explicitly mentioned and approved
+- [x] (R) GA target version is explicitly mentioned and approved
 
 ## Overview
 


### PR DESCRIPTION
### VEP Metadata

**Tracking issue**:
https://github.com/kubevirt/enhancements/issues/156

**SIG label**: 
/sig compute

### What this PR does
<!-- Please summarize the VEP update here -->

### Special notes for your reviewer
