### PR TITLE
Add initial CodeRabbit configuration

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,19 @@
+language: en-US
+
+reviews:
+  profile: chill
+  request_changes_workflow: false
+  auto_review:
+    enabled: false
+  tools:
+    trufflehog:
+      enabled: true
+
+knowledge_base:
+  opt_out: true
+  code_guidelines:
+    enabled: true
+    filePatterns:
+      - README.md
+      - veps/NNNN-vep-template/vep.md
+      - docs/feature-lifecycle.md


### PR DESCRIPTION
## What this PR does

Adds `.coderabbit.yaml` to enable CodeRabbit AI-assisted review on `kubevirt/enhancements`, as planned in [VEP #297](https://github.com/kubevirt/enhancements/blob/main/veps/meta-VEPs/297-coderabbit-adoption/vep.md).

## Design choices

**No path-specific instructions.** Rather than routing different file paths to different inline rule sets (which need updating as the repo evolves), the configuration relies entirely on the knowledge base.

**README.md as the central reference.** `README.md` already serves as the contribution guide for this repository. It is the single document to update when new policies or documents are added — CodeRabbit picks them up from there automatically, with no change to `.coderabbit.yaml` required.

The knowledge base seeds three stable files:
- `README.md` — contribution process, roles, and deadlines
- `veps/NNNN-vep-template/vep.md` — required structure for every VEP
- `docs/feature-lifecycle.md` — feature gate lifecycle policy

**Advisory only.** `chill` profile, `request_changes_workflow: false`, `auto_review: false`. CodeRabbit has no interaction with Prow's `/lgtm` or `/approve` flow.

## Tracking

Relates to [VEP #297](https://github.com/kubevirt/enhancements/blob/main/veps/meta-VEPs/297-coderabbit-adoption/vep.md) (CodeRabbit adoption) / issue #297.

## For Reviewers

In order to reference the VEP repo from other repos (e.g. k/kubevirt), we need to add the VEP repo to the coderabbit enabled projects at the org level.
This configuration should be added before coderabbit is added to assure it does not automatically triggers a review at this time. Once we are happy with the results, we will enable it automatically.