### PR TITLE
VEP 287: retarget TLS group preferences to v1.10 and adopt open string set

### DIFF
--- a/veps/sig-compute/287-tls-group-preferences/vep.md
+++ b/veps/sig-compute/287-tls-group-preferences/vep.md
@@ -4,7 +4,7 @@
 
 ### Target releases
 
-- This VEP targets alpha for version: v1.9.0
+- This VEP targets alpha for version: v1.10.0
 - This VEP targets beta for version:
 - This VEP targets GA for version:
 
@@ -30,8 +30,9 @@ groups such as `X25519MLKEM768`.
 The transition to Post-Quantum Cryptography (PQC) is underway. NIST has
 finalised its first set of PQC standards and IETF has standardised hybrid key
 exchange groups such as `X25519MLKEM768` that combine classical and
-post-quantum algorithms. Go 1.24 (which KubeVirt already uses) includes native
-support for `X25519MLKEM768` as a `tls.CurveID`.
+post-quantum algorithms. Go 1.24 added native support for `X25519MLKEM768` as a
+`tls.CurveID`, and the Go 1.26 toolchain KubeVirt now builds with additionally
+exposes the `SecP256r1MLKEM768` and `SecP384r1MLKEM1024` hybrid groups.
 
 KubeVirt's existing `TLSConfiguration` supports `MinTLSVersion` and `Ciphers`
 but has no mechanism to control which key exchange groups (elliptic curves) are
@@ -42,6 +43,21 @@ default curve preferences, which means administrators cannot:
 - Restrict curves to a known-safe set for compliance or FIPS requirements
 - Align KubeVirt's TLS behaviour with platform-wide or organisational TLS
   policies
+
+### Platform Alignment
+
+Some platforms mandate that every TLS endpoint in every container support
+configurable TLS groups (curves). This covers **all** endpoints, including
+metrics/Prometheus endpoints and admission webhooks, not just the primary API
+surfaces. KubeVirt must expose a `Groups` field on its existing
+`TLSConfiguration` so that a meta-operator can reconcile it from the
+cluster-wide TLS profile, mirroring how `ciphers` and `minTLSVersion` are
+already handled.
+
+Because a meta-operator can only adopt the API change once a KubeVirt release
+exposes the field — even an alpha release is sufficient — landing the `Groups`
+field in KubeVirt early is a prerequisite for the wider rollout. This is the
+primary reason for prioritising the alpha in v1.10.0.
 
 ### Why Not Automatically Enable PQC Groups?
 
@@ -69,14 +85,15 @@ support it. However, an explicit API field is still needed because:
   in virt-api, virt-controller, virt-handler, virt-operator,
   virt-exportproxy, virt-exportserver, virt-synchronization-controller,
   virt-template-apiserver, and virt-template-controller
-- Validate group names in the KubeVirt CR admission webhook
+- Enforce TLS-version/group compatibility via a declarative CEL validation on
+  `TLSConfiguration`, tolerating unrecognised group names gracefully
 - Maintain backward compatibility — omitting `Groups` preserves current Go
   default behaviour
 
 ## Non Goals
 
 - Watching platform-specific TLS profile resources directly from virt-operator
-  — meta-operators (e.g. HCO) handle this translation
+  — meta-operators handle this translation
 - Configuring TLS groups on client-side connections — this VEP covers
   server-side TLS endpoints only. Server-side configuration is sufficient to
   control which group is actually negotiated: the server selects the group
@@ -146,9 +163,11 @@ to enable the feature in lockstep with their platform's TLS group support.
 ### API Change
 
 Add a `Groups` field to `TLSConfiguration` in
-`staging/src/kubevirt.io/api/core/v1/types.go`:
+`staging/src/kubevirt.io/api/core/v1/types.go` as an open string set:
 
 ```go
+// TLSConfiguration holds TLS options
+// +kubebuilder:validation:XValidation:rule="!has(self.groups) || size(self.groups) == 0 || (has(self.minTLSVersion) && self.minTLSVersion == 'VersionTLS13') || !self.groups.exists(g, g in ['X25519MLKEM768','SecP256r1MLKEM768','SecP384r1MLKEM1024']) || self.groups.exists(g, g in ['X25519','secp256r1','secp384r1','secp521r1'])",message="a classical group (X25519, secp256r1, secp384r1 or secp521r1) is required in groups when minTLSVersion is below VersionTLS13 and a TLS 1.3-only group such as X25519MLKEM768 is configured"
 type TLSConfiguration struct {
     // ...existing fields...
     // +optional
@@ -157,24 +176,36 @@ type TLSConfiguration struct {
 }
 ```
 
-The `Groups` field uses `[]string` (matching the existing `Ciphers` pattern)
-rather than a typed enum. Group names use IANA TLS Supported Groups registry
-names (e.g. `X25519`, `secp256r1`, `X25519MLKEM768`), validated at webhook
-time against Go's `crypto/tls` supported curves via a `CurvePreferenceNameMap`.
+Group names use IANA TLS Supported Groups registry names (e.g. `X25519`,
+`secp256r1`, `X25519MLKEM768`). The names KubeVirt currently recognises are
+provided as convenience string constants (`TLSGroupX25519`, …,
+`TLSGroupSecP384r1MLKEM1024`) rather than a schema-enforced enumeration.
 
-This approach avoids requiring an API change when Go adds support for new
-groups (e.g. `SecP256r1MLKEM768` in a future Go version) and is consistent
-with how `Ciphers` already works in KubeVirt. It also accommodates builds
-that link alternative `crypto/tls` implementations.
+The field is deliberately an **open string set** rather than a typed enum, in
+line with the KubeVirt API design guidelines
+([kubevirt/kubevirt#18612](https://github.com/kubevirt/kubevirt/pull/18612),
+§3.2 "Open String Set (Avoiding Enums)"). A hard OpenAPI enum on an
+extensible-choice field is a rolling-upgrade hazard: a newer component that
+writes a newly-standardised group name would be rejected by an older
+apiserver's enum, so the guidelines require such fields to be modelled as open
+`string` primitives (§3.2.2). This also means a group added by a future Go
+release needs no API change — the constants and the mapping switch are simply
+extended.
 
-> **Note:** Go does not currently provide a public API for translating
-> curve/group names to `tls.CurveID` values (unlike cipher suites which have
-> `tls.CipherSuites()`). This requires maintaining a manual
-> `CurvePreferenceNameMap` in KubeVirt until Go provides an equivalent. There
-> is an upstream Go proposal to address this:
-> [golang/go#77712](https://github.com/golang/go/issues/77712). Once that
-> lands, KubeVirt can replace the manual map with Go's own API, eliminating the
-> maintenance burden. This is tracked as a Beta graduation requirement.
+Unrecognised group names are ingested without error and ignored at TLS setup
+time (see *Curve Name to ID Mapping* below), following the "Graceful Rejection"
+guidance in §3.2.3 — unknown values must not crash or hard-fail the object.
+
+The one cross-field constraint that must still be enforced (a recognised
+classical group is required when `MinTLSVersion` is below TLS 1.3 **and** a
+recognised TLS 1.3-only group is configured) is expressed declaratively as a
+CEL `x-kubernetes-validations` rule on `TLSConfiguration`, per §4.2 which
+prefers CEL (`XValidation`) over imperative admission webhooks for cross-field
+validation. See *Validation* below.
+
+> **Note:** Because `Groups` is an open string set, the mapping from a group
+> name to its `tls.CurveID` in `CurvePreferenceIds` is a small explicit switch
+> over the recognised names; any name not in the switch is silently skipped.
 
 ### TLS Setup Changes
 
@@ -211,6 +242,30 @@ When `Groups` is empty, `CurvePreferenceIds` returns `nil` and
 `CurvePreferences` is left unset, preserving Go's default behaviour (currently
 `X25519`, `secp256r1`, `secp384r1`, `secp521r1`, `X25519MLKEM768` in Go 1.24).
 
+#### Endpoint Coverage
+
+The platform alignment goal requires **every** TLS endpoint in every
+container to honour the configured groups, explicitly including
+metrics/Prometheus endpoints and admission webhooks — not just the primary API
+surfaces. The functions above are the complete set of TLS server-config
+construction points in KubeVirt, so applying `CurvePreferences` in each covers
+all endpoints:
+
+- **Metrics/Prometheus** endpoints are served via `SetupPromTLS`
+  (virt-controller, virt-handler, virt-operator).
+- **Admission/mutating webhooks** and the aggregated API are served via
+  `SetupTLSWithCertManager` (virt-api, virt-operator).
+- **virt-handler / synchronization-controller** server endpoints via
+  `SetupTLSForServer`; **exportproxy** via `SetupExportProxyTLS`;
+  **exportserver** via `buildServer`; **virt-template** components via the
+  injected `--tls-groups` flag.
+
+All KubeVirt TLS endpoints are served directly by the virt pods listed above;
+KubeVirt has no separately-managed operand endpoints that construct their own
+`tls.Config` outside these functions. The alpha implementation should confirm
+this list is exhaustive (e.g. by grepping for `tls.Config` construction across
+the tree) so no endpoint is missed.
+
 #### virt-exportserver
 
 The virt-exportserver binary is a special case. Unlike the other components, it
@@ -234,15 +289,20 @@ The `buildServer()` method (`exportserver.go:261`) then constructs a static
 
 ### Curve Name to ID Mapping
 
-Add `CurvePreferenceIds` and `CurvePreferenceNameMap` functions in
-`pkg/util/tls/tls.go`, analogous to the existing `CipherSuiteIds` and
-`CipherSuiteNameMap`. `CurvePreferenceNameMap` maps IANA group names to
-`tls.CurveID` values and is used by both the TLS setup functions and the
-admission webhook for validation.
+Add the following helper in `pkg/util/tls/tls.go`:
+
+- `CurvePreferenceIds([]string) []tls.CurveID` — converts the configured group
+  names to `tls.CurveID` values via an explicit switch over the recognised
+  names, used by the TLS setup functions. Unrecognised names are skipped, so an
+  older component tolerates group names added in a newer release (§3.2.3).
+
+No `ValidTLSGroup`/`IsTLS13OnlyGroup` helpers are needed: unknown names are
+ignored rather than rejected, and the TLS-version/group compatibility
+constraint is enforced declaratively via CEL rather than in Go.
 
 ### Deployment Injection
 
-Extend `InjectTLSConfigIntoDeployment` (`pkg/util/tls/tls.go:264`) to inject a
+Extend `InjectTLSConfigIntoDeployment` to inject a
 `--tls-groups` flag for virt-template components, matching the existing pattern
 for `--tls-cipher-suites` and `--tls-min-version`. The virt-template
 components currently do not accept a `--tls-groups` flag, so the flag must
@@ -250,18 +310,40 @@ be added to their startup code as part of this work.
 
 ### Validation
 
-Extend `validateTLSConfiguration` in
-`pkg/virt-operator/webhooks/kubevirt-update-admitter.go` to:
+Group validation is **declarative**, not imperative, in line with #18612 §4.2
+(prefer CEL over admission webhooks for cross-field validation) and §3.2.3
+(graceful handling of unrecognised values):
 
-1. **Validate group names** against the `CurvePreferenceNameMap` (dynamically
-   built from Go's `crypto/tls` supported curves), rejecting unknown names.
-2. **Validate TLS version and group compatibility** — PQC groups such as
-   `X25519MLKEM768` are TLS 1.3-only (Go filters them out for TLS 1.2
-   connections). If `MinTLSVersion` is below TLS 1.3 and `Groups` contains
-   only PQC groups, TLS 1.2 handshakes would fail with an empty curve list.
-   The webhook must reject this, requiring at least one classical group
-   (`X25519`, `secp256r1`, `secp384r1`, or `secp521r1`) when `MinTLSVersion`
-   is below `VersionTLS13`.
+1. **Unknown group names are not rejected.** They are ingested without error and
+   ignored at TLS setup time by `CurvePreferenceIds`, so an older component
+   tolerates group names written by a newer one during a rolling upgrade.
+2. **TLS version and group compatibility** is enforced by a CEL
+   `x-kubernetes-validations` rule on `TLSConfiguration` (the `XValidation`
+   marker shown under *API Change*). PQC groups such as `X25519MLKEM768` are
+   TLS 1.3-only (Go filters them out for TLS 1.2 connections); if
+   `MinTLSVersion` is below TLS 1.3 and, after unrecognised names are skipped,
+   the only mappable groups are TLS 1.3-only, a TLS 1.2 handshake would fail
+   with an empty curve list. The CEL rule rejects this at admission: when
+   `MinTLSVersion` is below `VersionTLS13` **and** `Groups` contains a
+   recognised TLS 1.3-only group (`X25519MLKEM768`, `SecP256r1MLKEM768`,
+   `SecP384r1MLKEM1024`), it requires at least one recognised classical group
+   (`X25519`, `secp256r1`, `secp384r1`, or `secp521r1`) to also be present.
+
+   The rule checks for the *presence of a recognised classical group* rather
+   than the *absence of a PQC group*. A negative check (`!(g in [PQC...])`)
+   would be satisfied by any unrecognised name — e.g. `Groups: [abcd,
+   X25519MLKEM768]` with `MinTLSVersion: VersionTLS12` would wrongly pass, yet
+   `abcd` is skipped at TLS setup, leaving only the TLS 1.3-only group and the
+   empty-curve failure the rule is meant to prevent. Gating the requirement on
+   a recognised PQC group being present (rather than firing whenever no
+   classical group is found) means a config that contains only unrecognised
+   names is **not** hard-failed, keeping §3.2.3 graceful handling intact —
+   such names are skipped at runtime and Go's defaults apply. The residual gap
+   is a *newly-standardised* TLS 1.3-only group not yet in the CEL list; this
+   errs on the side of permitting rather than falsely rejecting future names,
+   consistent with the open-string-set rationale under *API Change*.
+
+No group-specific logic is added to webhook admission validation.
 
 ### Meta-Operator Integration
 
@@ -307,8 +389,9 @@ spec:
         - X25519MLKEM768
 ```
 
-When `groups` is omitted, `CurvePreferences` is left unset on `tls.Config`
-and Go uses its built-in defaults.
+When `groups` is omitted, or when the `TLSGroupPreferences` feature gate is
+disabled, `CurvePreferences` is left unset on `tls.Config` and Go uses its
+built-in defaults.
 
 ## Alternatives
 
@@ -324,17 +407,26 @@ and apply the TLS configuration.
   platform configuration into KubeVirt CR fields
 - Breaks deployments on platforms that do not provide such a resource
 
-### Enum-Typed Groups
+### Typed `TLSGroup` Enum
 
-Use a `TLSGroup` enum type with kubebuilder validation instead of `[]string`.
+Model `Groups` as a typed `[]TLSGroup` with a hard
+`+kubebuilder:validation:Enum` covering the recognised group names, giving
+apiserver-level rejection of unknown values and a discoverable value set.
 
 **Rejected because:**
 
-- Requires an API change every time Go adds new group support
-- Doesn't accommodate builds linking alternative `crypto/tls` implementations
-- Inconsistent with how `Ciphers []string` already works in KubeVirt
-- Webhook validation against Go's runtime `crypto/tls` provides the same
-  safety without the maintenance burden
+- A hard OpenAPI enum on an extensible-choice field is disallowed by the
+  KubeVirt API design guidelines
+  ([kubevirt/kubevirt#18612](https://github.com/kubevirt/kubevirt/pull/18612),
+  §3.2). It is a rolling-upgrade hazard: a newer component writing a
+  newly-standardised group name is rejected by an older apiserver's enum.
+- Every newly-standardised group would force an API change (extend the enum),
+  whereas an open string set only needs the mapping switch extended.
+- The discoverability benefit is retained more cheaply via convenience string
+  constants plus the CEL compatibility rule, without the upgrade fragility.
+
+This aligns `Groups` with the existing `Ciphers []string` field, which is also
+an open string set.
 
 ### No Feature Gate
 
@@ -353,7 +445,7 @@ backward-compatible.
 No scalability impact. The group configuration is read once per TLS handshake
 via the existing `GetConfigForClient` callback, which already reads cipher and
 version configuration. The mapping from group names to `tls.CurveID` values
-is O(n) over a list of at most 5 entries.
+is O(n) over a short list (the handful of standardised groups).
 
 ## Update/Rollback Compatibility
 
@@ -401,9 +493,11 @@ is O(n) over a list of at most 5 entries.
 
 - `CurvePreferenceIds` returns correct `tls.CurveID` values for each group
 - `CurvePreferenceIds` returns nil for empty input
-- `CurvePreferenceIds` skips unknown group names
-- Validation rejects invalid group names
-- Validation accepts all valid group names
+- `CurvePreferenceIds` skips unknown group names and preserves order
+
+The TLS-version/group compatibility constraint is a CEL rule on
+`TLSConfiguration` and is exercised via the generated CRD rather than a Go unit
+test.
 
 ### Functional Tests
 
@@ -419,27 +513,36 @@ Extend `tests/infrastructure/tls-configuration.go`:
 
 ## Implementation History
 
+04-29-2026: Initial VEP proposed but implementation deferred from v1.9.0
+
+09-02-2026: Retargeted to Alpha in v1.10.0 behind the `TLSGroupPreferences`
+feature gate; adopted open string set API design with declarative CEL validation
+
 ## Graduation Requirements
 
 ### Alpha
 
 - [ ] Feature gate `TLSGroupPreferences` guards all code changes (disabled by
   default)
-- [ ] `Groups []string` field added to `TLSConfiguration`
-- [ ] `CurvePreferenceIds` mapping function in `pkg/util/tls/tls.go`
+- [ ] `Groups []string` open string set added to `TLSConfiguration` (no hard
+  enum, per #18612 §3.2), with convenience group-name constants
+- [ ] `CurvePreferenceIds([]string)` helper in `pkg/util/tls/tls.go`,
+  gracefully skipping unrecognised names
 - [ ] `CurvePreferences` set on `tls.Config` in all TLS setup functions
 - [ ] `--tls-groups` flag added to virt-template components
 - [ ] `InjectTLSConfigIntoDeployment` extended to inject `--tls-groups`
-- [ ] Admission webhook validation for group names and TLS version
-  compatibility
+- [ ] CEL `x-kubernetes-validations` rule on `TLSConfiguration` enforcing the
+  TLS-version/group compatibility constraint (#18612 §4.2)
 - [ ] Unit tests for mapping, validation, and TLS setup
 - [ ] Functional tests verifying group enforcement on virt pod endpoints
   (including virt-template components)
 
 ### Beta
 
-- [ ] Adopt upstream Go API for curve/group name resolution
-  ([golang/go#77712](https://github.com/golang/go/issues/77712)) if available,
-  replacing the manual `CurvePreferenceNameMap`
+- [ ] Soak the feature in alpha with no outstanding TLS-negotiation issues
+  reported against the configured groups
+- [ ] Keep the recognised group constants and the `CurvePreferenceIds` mapping
+  in step with the groups supported by the Go version KubeVirt ships, extending
+  them as new hybrid groups are standardised
 
 ### GA


### PR DESCRIPTION
### VEP Metadata

Tracking issue: https://github.com/kubevirt/enhancements/issues/287
SIG label: /sig compute

### What this PR does

Retargets VEP 287 (TLS Group Preferences) to v1.10.0 at Alpha maturity and finalises the API design. The VEP adds a `Groups` field to KubeVirt's `TLSConfiguration` so administrators (typically via a meta-operator such as HCO) can configure the TLS supported groups (elliptic curves) negotiated across all virt pod endpoints, enabling Post-Quantum Cryptography (PQC) readiness (e.g. `X25519MLKEM768`).

• **Targets Alpha in v1.10.0**, behind the `TLSGroupPreferences` feature gate (disabled by default). Following feedback on the kubevirt-dev exception request (https://groups.google.com/g/kubevirt-dev/c/SqaXG4rltq8/m/q0fn5ZnBAwAJ), the proposal keeps the standard Alpha lifecycle rather than skipping directly to Beta.
• **`Groups` modelled as an open string set** (`Groups []string`, no hard enum) per the KubeVirt API design guidelines ([kubevirt/kubevirt#18612](https://github.com/kubevirt/kubevirt/pull/18612), §3.2 "Open String Set (Avoiding Enums)"). A hard OpenAPI enum on an extensible-choice field is a rolling-upgrade hazard, so recognised group names are exposed as convenience constants instead. This matches the existing `Ciphers []string` precedent. The Alternatives section documents the typed `TLSGroup` enum as the rejected option.
• **Declarative validation** — the TLS-version/group compatibility constraint (a recognised classical group is required when `minTLSVersion` < TLS 1.3 and a recognised TLS 1.3-only group is configured) is a CEL `x-kubernetes-validations` rule on `TLSConfiguration` (#18612 §4.2). Unrecognised group names are ignored gracefully rather than rejected (§3.2.3), so no group-specific webhook logic is needed. The rule checks for the presence of a recognised classical group rather than the absence of a PQC group, so configs containing only unknown names are not hard-failed (per review feedback from @nunnatsa).
• **Endpoint Coverage** — confirms metrics/Prometheus and admission-webhook endpoints are covered and that KubeVirt has no separately-managed operand endpoints constructing their own `tls.Config`.

### Special notes for your reviewer

• Retargeted to Alpha for v1.10.0 following the kubevirt-dev freeze exception review where approvers declined the direct-to-Beta jump but granted the exception for Alpha.
• Addressed review feedback from @EdDev (removed specific codebase file paths to prevent doc drift) and @nunnatsa (explicitly mentioned HCO as an example meta-operator).
• The alpha implementation PR is [kubevirt/kubevirt#17553](https://github.com/kubevirt/kubevirt/pull/17553).
