### PR TITLE
Target vGPU migration for Beta in v1.10

### DIFF
--- a/veps/sig-compute/109-vgpu-live-migration/vep.md
+++ b/veps/sig-compute/109-vgpu-live-migration/vep.md
@@ -14,7 +14,7 @@ For example, during the planning phase for version v1.123, do **not** target bet
 -->
 
 - This VEP targets alpha for version: v1.9
-- This VEP targets beta for version: TBD
+- This VEP targets beta for version: v1.10
 - This VEP targets GA for version: TBD
 
 ### Release Signoff Checklist

--- a/veps/sig-compute/109-vgpu-live-migration/vep.md
+++ b/veps/sig-compute/109-vgpu-live-migration/vep.md
@@ -141,7 +141,9 @@ N/A
 ### Beta
 
 * KubeVirt will take hypervisor OS, Virtual GPU Manager version, and ECC configuration into account when scheduling migrations, relaxing the identical version requirement where NVIDIA allows (e.g., RHEL KVM 9.6+).
-* Find a way to estimate the maximum period for the migration 
+* Allow migration for VMs with multiple vGPUs.
+* Test migration alongside VEP 248 which added a stall detector (relevant for vGPU Migration since w/o VEP 248, migration cannot succeed unless we enable `AllowWorkloadDisruption`)
+* E2E Tests
 * Needs [VEP 141](https://github.com/kubevirt/enhancements/issues/141) to be in Beta.
 
 ### GA


### PR DESCRIPTION
### VEP Metadata

**Tracking issue**: https://github.com/kubevirt/enhancements/issues/109
**SIG label**: /sig compute

### What this PR does
Formalizes intention to move vGPU Live Migration to Beta in v1.10.

### Special notes for your reviewer
We are struggling to acquire the required hardware to test this feature at this time. I am hopeful that we will be able to acquire this hardware in time but this is a risk to actually getting this in for v1.10.