### PR TITLE
VEP #207: Add VEP Status Metadata and update completed status

### DIFF
--- a/veps/sig-compute/207-pause-probes/vep.md
+++ b/veps/sig-compute/207-pause-probes/vep.md
@@ -1,12 +1,22 @@
 # VEP: Probe Proxy for Manual Probe Control
 
-## Release Signoff Checklist
+## VEP Status Metadata
+
+### Target releases
+
+- This VEP targets alpha for version: 1.9.0, 1.10.0
+- This VEP targets beta for version:
+- This VEP targets GA for version:
+
+### Release Signoff Checklist
 
 Items marked with (R) are required *prior to targeting to a milestone / release*.
 
-- [ ] (R) Enhancement issue created, which links to VEP dir in [kubevirt/enhancements] (not the initial VEP PR)
-- [ ] (R) Target version is explicitly mentioned and approved
-- [ ] (R) Graduation criteria filled
+- [X] (R) Enhancement issue created, which links to VEP dir in [kubevirt/enhancements] (not the initial VEP PR)
+- [X] (R) Alpha target version is explicitly mentioned and approved
+- [ ] (R) Beta target version is explicitly mentioned and approved
+- [ ] (R) GA target version is explicitly mentioned and approved
+- [X] (R) Graduation criteria filled
 
 ## Overview
 
@@ -233,13 +243,13 @@ Same as Alternative 3, but paused flag via sentinel file (Alternative 2 approach
 ## Graduation Requirements
 
 **Alpha:**
-- [ ] Annotation pause/unpause works end-to-end
-- [ ] Logging at Info/Debug levels
-- [ ] Unit tests for paused/unpaused paths
-- [ ] E2E: set annotation → success without guest contact → remove → resume
+- [X] Annotation pause/unpause works end-to-end
+- [X] Logging at Info/Debug levels
+- [X] Unit tests for paused/unpaused paths
+- [X] E2E: set annotation → success without guest contact → remove → resume
 
 **Beta:**
-- [ ] Guest OS update workflow docs
+- [X] Guest OS update workflow docs
 
 **GA:**
 - [ ] Stable for ≥2 releases, no regressions


### PR DESCRIPTION
### VEP Metadata
Add the VEP Status Metadata section with target releases and update the release signoff and graduation checklists to reflect what is already done.

Assisted by: Claude Opus 4.8
**Tracking issue**: https://github.com/kubevirt/enhancements/issues/207
**SIG label**: /sig compute

### What this PR does
Add the VEP Status Metadata section with target releases and update the release signoff and graduation checklists to reflect what is already done.

Assisted by: Claude Opus 4.8

### Special notes for your reviewer
