### PR TITLE
VEP 168: Beta graduation (v1.11)

### DIFF
--- a/veps/sig-network/168-masquerade-port-ranges/vep.md
+++ b/veps/sig-network/168-masquerade-port-ranges/vep.md
@@ -5,7 +5,7 @@
 ### Target releases
 
 - This VEP targets alpha for version: v1.9
-- This VEP targets beta for version:
+- This VEP targets beta for version: v1.11
 - This VEP targets GA for version: 
 
 ## Release Signoff Checklist
@@ -14,7 +14,7 @@ Items marked with (R) are required _prior to targeting to a milestone / release_
 
 - [x] (R) Enhancement issue created, which links to VEP dir in [kubevirt/enhancements] (not the initial VEP PR)
 - [X] (R) Alpha target version is explicitly mentioned and approved
-- [] (R) Beta target version is explicitly mentioned and approved
+- [X] (R) Beta target version is explicitly mentioned and approved
 - [] (R) GA target version is explicitly mentioned and approved
 
 ## Overview
@@ -96,7 +96,7 @@ type Interface struct {
 
 The following validation rules will apply:
 
-- `PortRanges` and `Ports` cannot be used together in the same interface (Note: This mutual exclusivity constraint will be enforced for the Alpha release (v1.9) to simplify implementation; it may be relaxed in Beta or later).
+- During Beta, `Ports` and `PortRanges` can be used together in the same interface.
 - `PortRanges` can only be used on interfaces of type `masquerade` (not on other bindings).
 - Use of `PortRanges` is not allowed on secondary multus interfaces (this feature is only for the pod interface).
 - For each range, the `start` field must be less than or equal to `end`.
@@ -106,7 +106,7 @@ The following validation rules will apply:
 
 #### Note on mutual exclusivity
 
-This decision is deliberate: mutual exclusivity between `Ports` and `PortRanges` will be required during Alpha (v1.9) to keep implementation and validation simple and predictable. The team will revisit this constraint during Beta based on Alpha feedback and may allow combined usage (for example: single ports together with ranges) in a later release.
+Mutual exclusivity between `Ports` and `PortRanges` was required during Alpha (v1.9) to keep implementation and validation simple and predictable. During Beta (v1.11) the constraint is lifted: combined usage of single ports together with port ranges is now supported on the same interface.
 
 ### NFTables rules conversion
 
@@ -119,7 +119,7 @@ Proposed Feature Gate name: `MasqueradePortRanges`.
 
 ## API Examples
 
-The following example demonstrates a configuration using both fields. Note that in the Alpha phase, validation will enforce mutual exclusivity, preventing this specific combination. This example also illustrates that ranges of different protocols (TCP and UDP) are allowed to overlap.
+The following example demonstrates a configuration using both `ports` and `portRanges` on the same interface, which is supported starting from Beta (v1.11). It also illustrates that ranges of different protocols (TCP and UDP) are allowed to overlap.
 
 ```yaml
 apiVersion: kubevirt.io/v1
@@ -148,9 +148,9 @@ spec:
           pod: {}
 ```
 
-### Validation error example (Alpha)
+### Validation error example
 
-The following shows an invalid VM manifest that uses both `ports` and `portRanges` on the same interface (not allowed during Alpha), and an example of the API server validation error that should be returned when attempting to create it.
+The following shows an invalid VM manifest that uses two overlapping TCP `portRanges` on the same interface, and an example of the API server validation error that should be returned when attempting to create it.
 
 Invalid manifest:
 
@@ -167,13 +167,12 @@ spec:
           interfaces:
             - name: red
               masquerade: {}
-              ports:
-                - name: ssh
-                  port: 22
-                  protocol: TCP
               portRanges:
-                - start: 1000
-                  end: 2000
+                - start: 80
+                  end: 200
+                  protocol: TCP
+                - start: 150
+                  end: 300
                   protocol: TCP
       networks:
         - name: red
@@ -183,7 +182,7 @@ spec:
 Example API server validation output:
 
 ```text
-Error from server (Invalid): error when creating "invalid-vm.yaml": VirtualMachine.kubevirt.io "invalid-vm" is invalid: spec.template.spec.domain.devices.interfaces[0]: Invalid value: interface: "ports" and "portRanges" cannot be used together while the MasqueradePortRanges feature gate enforces mutual exclusivity in Alpha (v1.9)
+Error from server (Invalid): error when creating "invalid-vm.yaml": VirtualMachine.kubevirt.io "invalid-vm" is invalid: spec.template.spec.domain.devices.interfaces[0].portRanges: Invalid value: TCP portRanges [80-200] and [150-300] overlap
 ```
 
 ## Alternatives
@@ -300,6 +299,7 @@ The proposed modification poses no scalability problems: it can actually make fo
 - 2026-01-03: Initial VEP draft created.
 - 2026-04-08: Added explicit validation checks and nftables rules conversion subsection under Design.
 - 2026-04-08: Added Alpha/Beta/GA graduation plan and Feature Gate strategy.
+- 2026-09-08: Beta graduation (v1.11): feature gate graduated to Beta, combined `Ports` + `PortRanges` usage supported, E2E coverage added.
 
 ## Graduation Requirements
 
@@ -310,13 +310,13 @@ The proposed modification poses no scalability problems: it can actually make fo
 - [ ] Validation and forwarding of ranges for masquerade pod interface only
 - [ ] Initial feedback collection from users
 
-### Beta (v1.10)
+### Beta
 
-- [ ] Feature remains protected by a feature gate
-- [ ] Extended validation and functional coverage based on Alpha feedback
-- [ ] Decision recorded on whether combined `Ports` + `PortRanges` usage should be introduced in this phase or deferred
+- [X] Feature remains protected by a feature gate
+- [X] Extended validation and functional coverage based on Alpha feedback
+- [X] Decision recorded on whether combined `Ports` + `PortRanges` usage should be introduced in this phase or deferred (introduced in Beta)
 
-### GA (v1.11)
+### GA
 
 - [ ] Feature gate removed and feature enabled by default
 - [ ] Graduation criteria fully met with stable behavior


### PR DESCRIPTION
**What this PR does / why we need it:**

Records the Beta graduation of VEP 168 (Masquerade Port Ranges) for **v1.11** (the v1.10 window was missed, see https://github.com/kubevirt/enhancements/issues/168).

Changes:
- Set the Beta target release to v1.11 and update the release signoff checklist.
- Record the decision to introduce combined `ports` + `portRanges` usage in Beta, lifting the Alpha mutual exclusivity.
- Update the validation rules and the mutual exclusivity note accordingly.
- Replace the (now obsolete) mutual-exclusivity validation error example with an overlapping-TCP-ranges one, still valid in Beta.
- Mark the Beta graduation checklist items and update the implementation history.

**Related:**
- Complements #306 (VEP 168 touch-ups). This PR is scoped to the Beta graduation only; a rebase may be needed depending on the merge order with #306.
- Code implementation: kubevirt/kubevirt#19060 (gate graduation to Beta + combined usage + E2E).

**Special notes for your reviewer:**

This is the VEP adjustment required for the Beta graduation (gate remains protected during Beta; removal is planned for GA).

VEP tracking issue: https://github.com/kubevirt/enhancements/issues/168